### PR TITLE
feat: improve slug readability

### DIFF
--- a/schemas/link.ts
+++ b/schemas/link.ts
@@ -5,7 +5,7 @@ const { slugRegex } = useAppConfig()
 
 const slugDefaultLength = +useRuntimeConfig().public.slugDefaultLength
 
-export const nanoid = (length: number = slugDefaultLength) => customAlphabet('0123456789abcdefghijklmnopqrstuvwxyz', length)
+export const nanoid = (length: number = slugDefaultLength) => customAlphabet('23456789abcdefghjkmnpqrstuvwxyz', length)
 
 export const LinkSchema = z.object({
   id: z.string().trim().max(26).default(nanoid(10)),


### PR DESCRIPTION
remove `1` `l` `i` `0` `o` to avoid recognition mistake