### PR TITLE
feat: remove leading and trailing slash from slug

### DIFF
--- a/server/middleware/1.redirect.ts
+++ b/server/middleware/1.redirect.ts
@@ -3,7 +3,7 @@ import { parsePath, withQuery } from 'ufo'
 import type { LinkSchema } from '@/schemas/link'
 
 export default eventHandler(async (event) => {
-  const { pathname: slug } = parsePath(event.path.slice(1)) // remove leading slash
+  const { pathname: slug } = parsePath(event.path.replace(/^\/|\/$/g, '')) // remove leading and trailing slashes
   const { slugRegex, reserveSlug } = useAppConfig(event)
   const { homeURL, linkCacheTtl, redirectWithQuery } = useRuntimeConfig(event)
   const { cloudflare } = event.context


### PR DESCRIPTION
Currently if a created short link is used with a trailing slash the user is show a 404 page. 
For example: [https://sink.cool/0](https://sink.cool/0) works just fine but [https://sink.cool/0/](https://sink.cool/0/) does not redirect to the correct target page.

closes: #56 