### PR TITLE
docs: update KV Namespace setting path & add docs URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ We welcome your contributions and PRs.
 
 5. Save and deploy the project.
 6. Cancel the deployment, then navigate to **Settings** -> **Bindings** -> **Add**:
-   - **KV Namespace**: Bind the variable name `KV` to a KV namespace (create a new one under **Workers & Pages** -> **KV**).
+   - **KV Namespace**: Bind the variable name `KV` to a [KV namespace](https://developers.cloudflare.com/kv/) (create a new one under **Storage & Databases** -> **KV**). 
    - **Workers AI** (_Optional_): Bind the variable name `AI` to the Workers AI Catalog.
    - **Analytics Engine**:
      - In **Workers & Pages**, go to **Account details** on the right side, find `Analytics Engine`, and click `Set up` to enable the free version.


### PR DESCRIPTION
Updates the KV Namespace settings path and adds cloudflare documentation path for it.