### PR TITLE
feat: Add internationalization (i18n) support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -46,5 +46,22 @@
     "scss",
     "pcss",
     "postcss"
-  ]
+  ],
+  "i18n-ally.dirStructure": "auto",
+  "i18n-ally.localesPaths": [
+    "i18n/locales"
+  ],
+  "i18n-ally.extract.keygenStyle": "camelCase",
+  "i18n-ally.keystyle": "nested",
+  "i18n-ally.enabledParsers": [
+    "json"
+  ],
+  "i18n-ally.namespace": true,
+  "i18n-ally.sortKeys": true,
+  "i18n-ally.sourceLanguage": "en-US",
+  "i18n-ally.displayLanguage": "en-US",
+  "i18n-ally.parsers.typescript.compilerOptions": {
+    "moduleResolution": "node"
+  },
+  "i18n-ally.enabledFrameworks": ["vue"]
 }

--- a/components/SwitchTheme.vue
+++ b/components/SwitchTheme.vue
@@ -14,7 +14,7 @@ const colorMode = useColorMode()
         <Moon
           class="w-5 h-5 transition-all scale-0 dark:scale-100"
         />
-        <span class="sr-only">Toggle theme</span>
+        <span class="sr-only">{{ $t('theme.toggle') }}</span>
       </Button>
     </DropdownMenuTrigger>
     <DropdownMenuContent
@@ -26,21 +26,21 @@ const colorMode = useColorMode()
         @click="colorMode.preference = 'light'"
       >
         <Sun class="w-4 h-4 mr-1" />
-        Light
+        {{ $t('theme.light') }}
       </DropdownMenuItem>
       <DropdownMenuItem
         class="cursor-pointer"
         @click="colorMode.preference = 'dark'"
       >
         <Moon class="w-4 h-4 mr-1" />
-        Dark
+        {{ $t('theme.dark') }}
       </DropdownMenuItem>
       <DropdownMenuItem
         class="cursor-pointer"
         @click="colorMode.preference = 'system'"
       >
         <Laptop class="w-4 h-4 mr-1" />
-        System
+        {{ $t('theme.system') }}
       </DropdownMenuItem>
     </DropdownMenuContent>
   </DropdownMenu>

--- a/components/dashboard/Breadcrumb.vue
+++ b/components/dashboard/Breadcrumb.vue
@@ -24,7 +24,7 @@ const { title } = useAppConfig()
           :as="NuxtLink"
           to="/dashboard"
         >
-          Dashboard
+          {{ $t('dashboard.title') }}
         </BreadcrumbLink>
       </BreadcrumbItem>
       <BreadcrumbSeparator />

--- a/components/dashboard/Counters.vue
+++ b/components/dashboard/Counters.vue
@@ -44,7 +44,7 @@ onBeforeUnmount(() => {
     <Card>
       <CardHeader class="flex flex-row justify-between items-center pb-2 space-y-0">
         <CardTitle class="text-sm font-medium">
-          Visits
+          {{ $t('dashboard.visits') }}
         </CardTitle>
         <MousePointerClick class="w-4 h-4 text-muted-foreground" />
       </CardHeader>
@@ -55,7 +55,7 @@ onBeforeUnmount(() => {
     <Card>
       <CardHeader class="flex flex-row justify-between items-center pb-2 space-y-0">
         <CardTitle class="text-sm font-medium">
-          Visitors
+          {{ $t('dashboard.visitors') }}
         </CardTitle>
         <Users class="w-4 h-4 text-muted-foreground" />
       </CardHeader>
@@ -66,7 +66,7 @@ onBeforeUnmount(() => {
     <Card>
       <CardHeader class="flex flex-row justify-between items-center pb-2 space-y-0">
         <CardTitle class="text-sm font-medium">
-          Referers
+          {{ $t('dashboard.referers') }}
         </CardTitle>
         <Flame class="w-4 h-4 text-muted-foreground" />
       </CardHeader>

--- a/components/dashboard/DatePicker.vue
+++ b/components/dashboard/DatePicker.vue
@@ -97,32 +97,32 @@ onBeforeMount(() => {
     </SelectTrigger>
     <SelectContent>
       <SelectItem value="today">
-        Today
+        {{ $t('dashboard.date_picker.today') }}
       </SelectItem>
       <SelectItem value="last-24h">
-        Last 24 hours
+        {{ $t('dashboard.date_picker.last_24h') }}
       </SelectItem>
       <SelectSeparator />
       <SelectItem value="this-week">
-        This week
+        {{ $t('dashboard.date_picker.this_week') }}
       </SelectItem>
       <SelectItem value="last-7d">
-        Last 7 days
+        {{ $t('dashboard.date_picker.last_7d') }}
       </SelectItem>
       <SelectSeparator />
       <SelectItem value="this-month">
-        This month
+        {{ $t('dashboard.date_picker.this_month') }}
       </SelectItem>
       <SelectItem value="last-30d">
-        Last 30 days
+        {{ $t('dashboard.date_picker.last_30d') }}
       </SelectItem>
       <SelectSeparator />
       <SelectItem value="last-90d">
-        Last 90 days
+        {{ $t('dashboard.date_picker.last_90d') }}
       </SelectItem>
       <SelectSeparator />
       <SelectItem value="custom">
-        Custom
+        {{ $t('dashboard.date_picker.custom') }}
       </SelectItem>
     </SelectContent>
   </Select>
@@ -130,7 +130,7 @@ onBeforeMount(() => {
   <Dialog v-model:open="openCustomDateRange">
     <DialogContent class="w-auto max-w-[95svw] max-h-[95svh] md:max-w-screen-md grid-rows-[auto_minmax(0,1fr)_auto]">
       <DialogHeader>
-        <DialogTitle>Custom Date</DialogTitle>
+        <DialogTitle>{{ $t('dashboard.date_picker.custom_title') }}</DialogTitle>
       </DialogHeader>
       <Tabs
         default-value="range"
@@ -138,10 +138,10 @@ onBeforeMount(() => {
         <div class="flex justify-center">
           <TabsList>
             <TabsTrigger value="date">
-              Date
+              {{ $t('dashboard.date_picker.single_date') }}
             </TabsTrigger>
             <TabsTrigger value="range">
-              Date Range
+              {{ $t('dashboard.date_picker.date_range') }}
             </TabsTrigger>
           </TabsList>
         </div>

--- a/components/dashboard/Index.vue
+++ b/components/dashboard/Index.vue
@@ -67,7 +67,7 @@ onBeforeMount(() => {
           #left
         >
           <h3 class="text-xl font-bold leading-10">
-            {{ link.slug }}'s Stats
+            {{ link.slug }} {{ $t('dashboard.stats') }}
           </h3>
         </template>
         <DashboardDatePicker @update:date-range="changeDate" />

--- a/components/dashboard/Logout.vue
+++ b/components/dashboard/Logout.vue
@@ -16,15 +16,15 @@ function logOut() {
     </AlertDialogTrigger>
     <AlertDialogContent class="max-w-[95svw] max-h-[95svh] md:max-w-lg grid-rows-[auto_minmax(0,1fr)_auto]">
       <AlertDialogHeader>
-        <AlertDialogTitle>LogOut ?</AlertDialogTitle>
+        <AlertDialogTitle>{{ $t('logout.title') }}</AlertDialogTitle>
         <AlertDialogDescription>
-          Are you sure you want to log out ?
+          {{ $t('logout.confirm') }}
         </AlertDialogDescription>
       </AlertDialogHeader>
       <AlertDialogFooter>
-        <AlertDialogCancel>Cancel</AlertDialogCancel>
+        <AlertDialogCancel>{{ $t('common.cancel') }}</AlertDialogCancel>
         <AlertDialogAction @click="logOut">
-          LogOut
+          {{ $t('logout.action') }}
         </AlertDialogAction>
       </AlertDialogFooter>
     </AlertDialogContent>

--- a/components/dashboard/Nav.vue
+++ b/components/dashboard/Nav.vue
@@ -13,10 +13,10 @@ const route = useRoute()
         <TabsTrigger
           value="/dashboard/links"
         >
-          Links
+          {{ $t('nav.links') }}
         </TabsTrigger>
         <TabsTrigger value="/dashboard/analysis">
-          Analysis
+          {{ $t('nav.analysis') }}
         </TabsTrigger>
       </TabsList>
     </Tabs>

--- a/components/dashboard/Views.vue
+++ b/components/dashboard/Views.vue
@@ -62,7 +62,7 @@ function formatTime(tick) {
 <template>
   <Card class="px-0 py-6 md:px-6">
     <CardTitle class="px-6 md:px-0">
-      Views
+      {{ $t('dashboard.views') }}
     </CardTitle>
     <component
       :is="chart"

--- a/components/dashboard/links/Delete.vue
+++ b/components/dashboard/links/Delete.vue
@@ -29,15 +29,15 @@ async function deleteLink() {
     </AlertDialogTrigger>
     <AlertDialogContent class="max-w-[95svw] max-h-[95svh] md:max-w-lg grid-rows-[auto_minmax(0,1fr)_auto]">
       <AlertDialogHeader>
-        <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+        <AlertDialogTitle>{{ $t('links.delete_confirm_title') }}</AlertDialogTitle>
         <AlertDialogDescription>
-          This action cannot be undone. This will really delete your link from servers.
+          {{ $t('links.delete_confirm_desc') }}
         </AlertDialogDescription>
       </AlertDialogHeader>
       <AlertDialogFooter>
-        <AlertDialogCancel>Cancel</AlertDialogCancel>
+        <AlertDialogCancel>{{ $t('common.cancel') }}</AlertDialogCancel>
         <AlertDialogAction @click="deleteLink">
-          Continue
+          {{ $t('common.continue') }}
         </AlertDialogAction>
       </AlertDialogFooter>
     </AlertDialogContent>

--- a/components/dashboard/links/Editor.vue
+++ b/components/dashboard/links/Editor.vue
@@ -116,10 +116,10 @@ async function onSubmit(formData) {
   dialogOpen.value = false
   emit('update:link', newLink, isEdit ? 'edit' : 'create')
   if (isEdit) {
-    toast('Link updated successfully')
+    toast(t('links.update_success'))
   }
   else {
-    toast('Link created successfully')
+    toast(t('links.create_success'))
   }
 }
 
@@ -135,19 +135,19 @@ const { previewMode } = useRuntimeConfig().public
           variant="outline"
           @click="randomSlug"
         >
-          Create Link
+          {{ $t('links.create') }}
         </Button>
       </slot>
     </DialogTrigger>
     <DialogContent class="max-w-[95svw] max-h-[95svh] md:max-w-lg grid-rows-[auto_minmax(0,1fr)_auto]">
       <DialogHeader>
-        <DialogTitle>{{ link.id ? 'Edit Link' : 'Create Link' }}</DialogTitle>
+        <DialogTitle>{{ link.id ? $t('links.edit') : $t('links.create') }}</DialogTitle>
       </DialogHeader>
       <p
         v-if="previewMode"
         class="text-sm text-muted-foreground"
       >
-        The preview mode link is valid for up to 24 hours.
+        {{ $t('links.preview_mode_tip') }}
       </p>
       <AutoForm
         class="px-2 space-y-2 overflow-y-auto"
@@ -185,11 +185,11 @@ const { previewMode } = useRuntimeConfig().public
               variant="secondary"
               class="mt-2 sm:mt-0"
             >
-              Close
+              {{ $t('common.close') }}
             </Button>
           </DialogClose>
           <Button type="submit">
-            Save
+            {{ $t('common.save') }}
           </Button>
         </DialogFooter>
       </AutoForm>

--- a/components/dashboard/links/Index.vue
+++ b/components/dashboard/links/Index.vue
@@ -80,15 +80,15 @@ function updateLinkList(link, type) {
       v-if="!isLoading && listComplete"
       class="flex items-center justify-center text-sm"
     >
-      No more links
+      {{ $t('links.no_more') }}
     </div>
     <div
       v-if="listError"
       class="flex items-center justify-center text-sm"
     >
-      Loading links failed,
+      {{ $t('links.load_failed') }}
       <Button variant="link" @click="getLinks">
-        Try again
+        {{ $t('common.try_again') }}
       </Button>
     </div>
   </main>

--- a/components/dashboard/links/Link.vue
+++ b/components/dashboard/links/Link.vue
@@ -13,6 +13,7 @@ const props = defineProps({
 })
 const emit = defineEmits(['update:link'])
 
+const { t } = useI18n()
 const editPopoverOpen = ref(false)
 
 const { host, origin } = location
@@ -30,6 +31,11 @@ const { copy, copied } = useClipboard({ source: shortLink.value, copiedDuring: 4
 function updateLink(link, type) {
   emit('update:link', link, type)
   editPopoverOpen.value = false
+}
+
+function copyLink() {
+  copy(shortLink)
+  toast(t('links.copy_success'))
 }
 </script>
 
@@ -69,7 +75,7 @@ function updateLink(link, type) {
             <Copy
               v-else
               class="w-4 h-4 ml-1 shrink-0"
-              @click.prevent="copy(shortLink);toast('Copy successful!')"
+              @click.prevent="copyLink"
             />
           </div>
 
@@ -134,7 +140,7 @@ function updateLink(link, type) {
                 <SquarePen
                   class="w-5 h-5 mr-2"
                 />
-                Edit
+                {{ $t('common.edit') }}
               </div>
             </DashboardLinksEditor>
 
@@ -149,7 +155,7 @@ function updateLink(link, type) {
               >
                 <Eraser
                   class="w-5 h-5 mr-2"
-                /> Delete
+                /> {{ $t('common.delete') }}
               </div>
             </DashboardLinksDelete>
           </PopoverContent>

--- a/components/dashboard/links/QRCode.vue
+++ b/components/dashboard/links/QRCode.vue
@@ -119,7 +119,7 @@ onMounted(() => {
       </div>
       <Button variant="outline" @click="downloadQRCode">
         <Download class="w-4 h-4 mr-2" />
-        Download QR Code
+        {{ $t('links.download_qr_code') }}
       </Button>
     </div>
   </div>

--- a/components/dashboard/links/Search.vue
+++ b/components/dashboard/links/Search.vue
@@ -59,8 +59,8 @@ onMounted(() => {
       size="sm"
       class="relative justify-start w-full h-10 bg-background text-muted-foreground sm:w-32 md:w-48"
     >
-      <span class="hidden md:inline-flex">Search Links...</span>
-      <span class="inline-flex md:hidden">Search</span>
+      <span class="hidden md:inline-flex">{{ $t('links.search_placeholder') }}</span>
+      <span class="inline-flex md:hidden">{{ $t('common.search') }}</span>
       <kbd class="pointer-events-none absolute right-[0.3rem] top-[0.6rem] hidden h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium opacity-100 sm:flex">
         <span class="text-xs">⌘</span>K
       </kbd>
@@ -68,12 +68,12 @@ onMounted(() => {
   </TriggerTemplate>
   <SearchTemplate>
     <Command v-model:search-term="searchTerm" v-model="selectedLink" class="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
-      <CommandInput placeholder="Type to search..." />
-      <CommandList :class="{ 'max-h-none': !isDesktop }">
+      <CommandInput :placeholder="$t('links.search_placeholder')" />
+      <CommandList>
         <CommandEmpty v-if="searchTerm">
-          No links found.
+          {{ $t('links.no_results') }}
         </CommandEmpty>
-        <CommandGroup heading="Links">
+        <CommandGroup :heading="$t('links.group_title')">
           <CommandItem v-for="link in filteredLinks" :key="link.item?.id" class="cursor-pointer" :value="link.item" @select="selectLink(link.item)">
             <div class="flex gap-1 w-full">
               <div class="inline-flex overflow-hidden flex-1 gap-1 items-center">

--- a/components/dashboard/metrics/Group.vue
+++ b/components/dashboard/metrics/Group.vue
@@ -1,44 +1,39 @@
 <script setup>
-import pluralize from 'pluralize'
-
 defineProps({
   tabs: {
     type: Array,
     required: true,
   },
+  rawTabs: {
+    type: Array,
+    required: true,
+  },
 })
-
-function type2name(type) {
-  if (['os'].includes(type))
-    return type.toUpperCase()
-
-  return pluralize(type.replace(type[0], type[0].toUpperCase()))
-}
 </script>
 
 <template>
   <Tabs
-    :default-value="tabs[0]"
+    :default-value="rawTabs[0]"
     class="flex flex-col"
   >
     <TabsList class="w-fit">
       <TabsTrigger
-        v-for="tab in tabs"
+        v-for="(tab, index) in tabs"
         :key="tab"
-        :value="tab"
+        :value="rawTabs[index]"
       >
-        {{ type2name(tab) }}
+        {{ tab }}
       </TabsTrigger>
     </TabsList>
     <TabsContent
-      v-for="tab in tabs"
+      v-for="(tab, index) in tabs"
       :key="tab"
-      :value="tab"
+      :value="rawTabs[index]"
       class="flex-1"
     >
       <DashboardMetricsMetric
-        :type="tab"
-        :name="type2name(tab)"
+        :type="rawTabs[index]"
+        :name="tab"
         class="h-full"
       />
     </TabsContent>

--- a/components/dashboard/metrics/Index.vue
+++ b/components/dashboard/metrics/Index.vue
@@ -1,25 +1,50 @@
+<script setup>
+const { t } = useI18n()
+
+const tabs = {
+  location: ['country', 'region', 'city'],
+  referer: ['referer', 'slug'],
+  time: ['language', 'timezone'],
+  device: ['device', 'deviceType'],
+  browser: ['os', 'browser', 'browserType'],
+}
+
+const translatedTabs = computed(() => ({
+  location: tabs.location.map(tab => t(`dashboard.metrics.${tab}`)),
+  referer: tabs.referer.map(tab => t(`dashboard.metrics.${tab}`)),
+  time: tabs.time.map(tab => t(`dashboard.metrics.${tab}`)),
+  device: tabs.device.map(tab => t(`dashboard.metrics.${tab}`)),
+  browser: tabs.browser.map(tab => t(`dashboard.metrics.${tab}`)),
+}))
+</script>
+
 <template>
   <main class="grid gap-8 lg:grid-cols-12">
     <LazyDashboardMetricsLocations class="col-span-1 lg:col-span-8" />
     <DashboardMetricsGroup
       class="lg:col-span-4"
-      :tabs="['country', 'region', 'city']"
+      :tabs="translatedTabs.location"
+      :raw-tabs="tabs.location"
     />
     <DashboardMetricsGroup
       class="lg:col-span-6"
-      :tabs="['referer', 'slug']"
+      :tabs="translatedTabs.referer"
+      :raw-tabs="tabs.referer"
     />
     <DashboardMetricsGroup
       class="lg:col-span-6"
-      :tabs="['language', 'timezone']"
+      :tabs="translatedTabs.time"
+      :raw-tabs="tabs.time"
     />
     <DashboardMetricsGroup
       class="lg:col-span-6"
-      :tabs="['device', 'deviceType']"
+      :tabs="translatedTabs.device"
+      :raw-tabs="tabs.device"
     />
     <DashboardMetricsGroup
       class="lg:col-span-6"
-      :tabs="['os', 'browser', 'browserType']"
+      :tabs="translatedTabs.browser"
+      :raw-tabs="tabs.browser"
     />
   </main>
 </template>

--- a/components/dashboard/metrics/List.vue
+++ b/components/dashboard/metrics/List.vue
@@ -21,12 +21,12 @@ defineProps({
       <div
         class="h-12 px-4 font-medium text-left align-middle text-muted-foreground "
       >
-        Name
+        {{ $t('dashboard.name') }}
       </div>
       <div
         class="h-12 px-4 font-medium text-right align-middle text-muted-foreground"
       >
-        Count
+        {{ $t('dashboard.count') }}
       </div>
     </div>
     <VList

--- a/components/dashboard/metrics/Locations.vue
+++ b/components/dashboard/metrics/Locations.vue
@@ -64,7 +64,7 @@ const Tooltip = {
 <template>
   <Card class="flex flex-col md:h-[500px]">
     <CardHeader>
-      <CardTitle>Locations</CardTitle>
+      <CardTitle>{{ $t('dashboard.locations') }}</CardTitle>
     </CardHeader>
     <CardContent class="flex-1 flex [&_[data-radix-aspect-ratio-wrapper]]:flex-1">
       <AspectRatio :ratio="65 / 30">

--- a/components/dashboard/metrics/Metric.vue
+++ b/components/dashboard/metrics/Metric.vue
@@ -75,9 +75,8 @@ onBeforeUnmount(() => {
             <Button
               variant="link"
             >
-              <Maximize
-                class="mr-2 w-4 h-4"
-              /> DETAILS
+              <Maximize class="w-4 h-4 mr-2" />
+              {{ $t('dashboard.details') }}
             </Button>
           </DialogTrigger>
           <DialogContent class="max-w-[95svw] max-h-[95svh] md:max-w-screen-md grid-rows-[auto_minmax(0,1fr)_auto]">

--- a/components/dashboard/metrics/name/Index.vue
+++ b/components/dashboard/metrics/name/Index.vue
@@ -53,7 +53,7 @@ function formatName(name, type) {
           v-else
           class="w-full truncate"
         >
-          {{ formatName(name, type) || '(None)' }}
+          {{ formatName(name, type) || $t('dashboard.none') }}
         </div>
       </TooltipTrigger>
       <TooltipContent v-if="name">

--- a/components/home/Cta.vue
+++ b/components/home/Cta.vue
@@ -3,18 +3,18 @@
     class="flex flex-col items-center max-w-4xl p-8 mx-auto my-12 text-center bg-black rounded-lg md:px-20 md:py-20"
   >
     <h2 class="text-4xl tracking-tight text-white md:text-6xl">
-      Deployment immediately
+      {{ $t('home.cta.title') }}
     </h2>
     <p class="mt-4 text-lg text-slate-400 md:text-xl">
-      With just a few simple clicks, you can start deploying without any expenses.
+      {{ $t('home.cta.description') }}
     </p>
     <div class="flex mt-5">
       <HomeLink
         href="https://github.com/ccbikai/sink?tab=readme-ov-file#%EF%B8%8F-deployment"
         type="inverted"
-        title="Start Deploy"
+        :title="$t('home.cta.button')"
       >
-        Start Deploy
+        {{ $t('home.cta.button') }}
       </HomeLink>
     </div>
   </div>

--- a/components/home/Features.vue
+++ b/components/home/Features.vue
@@ -1,41 +1,36 @@
 <script setup>
 import { AreaChart, Hourglass, Link, Paintbrush, ServerOff, Sparkles } from 'lucide-vue-next'
 
-const features = ref([
+const { t } = useI18n()
+const features = computed(() => [
   {
-    title: 'URL Shortening',
-    description:
-          'Compress your URLs to their minimal length.',
+    title: t('home.features.url_shortening.title'),
+    description: t('home.features.url_shortening.description'),
     icon: Link,
   },
   {
-    title: 'Analytics',
-    description:
-          'Monitor link analytics and gather insightful statistics.',
+    title: t('home.features.analytics.title'),
+    description: t('home.features.analytics.description'),
     icon: AreaChart,
   },
   {
-    title: 'Serverless',
-    description:
-          'Deploy without the need for traditional servers.',
+    title: t('home.features.serverless.title'),
+    description: t('home.features.serverless.description'),
     icon: ServerOff,
   },
   {
-    title: 'Customizable Slug',
-    description:
-          'Support for personalized slugs and case sensitivity.',
+    title: t('home.features.customizable_slug.title'),
+    description: t('home.features.customizable_slug.description'),
     icon: Paintbrush,
   },
   {
-    title: 'AI Slug',
-    description:
-          'Leverage AI to generate slugs.',
+    title: t('home.features.ai_slug.title'),
+    description: t('home.features.ai_slug.description'),
     icon: Sparkles,
   },
   {
-    title: 'Link Expiration',
-    description:
-          'Set expiration dates for your links.',
+    title: t('home.features.link_expiration.title'),
+    description: t('home.features.link_expiration.description'),
     icon: Hourglass,
   },
 ])
@@ -45,10 +40,10 @@ const features = ref([
   <main class="pt-16 md:py-12">
     <div class="md:pb-12">
       <h2 class="text-4xl font-bold lg:text-5xl lg:tracking-tight">
-        Features
+        {{ $t('home.features.title') }}
       </h2>
       <p class="my-8 text-lg md:mb-0 text-slate-600">
-        Simple and sufficient functionality
+        {{ $t('home.features.subtitle') }}
       </p>
     </div>
 

--- a/components/home/Hero.vue
+++ b/components/home/Hero.vue
@@ -30,7 +30,7 @@ const { title, description, github } = useAppConfig()
           <AreaChart
             class="w-5 h-5"
           />
-          Dashboard
+          {{ $t('dashboard.title') }}
         </HomeLink>
         <HomeLink
           size="lg"

--- a/components/home/Logos.vue
+++ b/components/home/Logos.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="mt-16 md:mt-0 md:py-12 ">
     <h2 class="font-bold text-center text-slate-600">
-      Built with awesome technologies
+      {{ $t('home.logos.title') }}
     </h2>
     <div class="flex flex-wrap items-center justify-center gap-8 mt-10 md:gap-20">
       <img

--- a/components/home/Twitter.vue
+++ b/components/home/Twitter.vue
@@ -17,7 +17,7 @@ const { twitter } = useAppConfig()
       orientation="vertical"
       class="h-4"
     />
-    <span>Follow me on X(Twitter)</span>
+    <span>{{ $t('home.twitter.follow') }}</span>
     <ArrowRight class="w-4 h-4" />
   </a>
 </template>

--- a/components/layouts/Footer.vue
+++ b/components/layouts/Footer.vue
@@ -29,7 +29,7 @@ const { title, email, telegram, blog, twitter, mastodon, github } = useAppConfig
           title="Email"
           class="text-gray-400 hover:text-gray-500"
         >
-          <span class="sr-only">Email</span>
+          <span class="sr-only">{{ $t('layouts.footer.social.email') }}</span>
           <GmailIcon
             class="w-6 h-6"
           />
@@ -41,7 +41,7 @@ const { title, email, telegram, blog, twitter, mastodon, github } = useAppConfig
           title="Telegram"
           class="text-gray-400 hover:text-gray-500"
         >
-          <span class="sr-only">Telegram</span>
+          <span class="sr-only">{{ $t('layouts.footer.social.telegram') }}</span>
           <TelegramIcon
             class="w-6 h-6"
           />
@@ -53,7 +53,7 @@ const { title, email, telegram, blog, twitter, mastodon, github } = useAppConfig
           title="Blog"
           class="text-gray-400 hover:text-gray-500"
         >
-          <span class="sr-only">Blog</span>
+          <span class="sr-only">{{ $t('layouts.footer.social.blog') }}</span>
           <BloggerIcon
             class="w-6 h-6"
           />
@@ -66,7 +66,7 @@ const { title, email, telegram, blog, twitter, mastodon, github } = useAppConfig
           title="Twitter"
           class="text-gray-400 hover:text-gray-500"
         >
-          <span class="sr-only">Twitter</span>
+          <span class="sr-only">{{ $t('layouts.footer.social.twitter') }}</span>
           <XIcon
             class="w-6 h-6"
           />
@@ -79,7 +79,7 @@ const { title, email, telegram, blog, twitter, mastodon, github } = useAppConfig
           title="Mastodon"
           class="text-gray-400 hover:text-gray-500"
         >
-          <span class="sr-only">Mastodon</span>
+          <span class="sr-only">{{ $t('layouts.footer.social.mastodon') }}</span>
           <MastodonIcon
             class="w-6 h-6"
           />
@@ -92,7 +92,7 @@ const { title, email, telegram, blog, twitter, mastodon, github } = useAppConfig
           title="GitHub"
           class="text-gray-400 hover:text-gray-500"
         >
-          <span class="sr-only">GitHub</span>
+          <span class="sr-only">{{ $t('layouts.footer.social.github') }}</span>
           <GitHubIcon
             class="w-6 h-6"
           />

--- a/components/layouts/Header.vue
+++ b/components/layouts/Header.vue
@@ -5,6 +5,15 @@ import SwitchTheme from '../SwitchTheme.vue'
 
 const showMenu = ref(false)
 const { title, github } = useAppConfig()
+
+const nuxtApp = useNuxtApp()
+const i18n = nuxtApp.$i18n
+const { setLocale, locales } = useI18n()
+const currentLocale = ref(i18n.locale.value)
+
+watch(currentLocale, (newLocale) => {
+  setLocale(newLocale)
+})
 </script>
 
 <template>
@@ -58,13 +67,13 @@ const { title, github } = useAppConfig()
             </a>
             <div class="w-full mx-4" />
             <div
-              class="flex flex-col items-start justify-end w-full pt-4 md:items-center md:w-1/3 md:flex-row md:py-0"
+              class="flex flex-col items-start justify-end w-full pt-4 md:items-center md:w-3/5 md:flex-row md:py-0"
             >
               <a
                 class="w-full px-6 py-2 mr-0 text-gray-700 cursor-pointer dark:text-gray-300 md:px-3 md:mr-2 lg:mr-3 md:w-auto"
                 href="/dashboard"
                 :title="`${title} Dashboard`"
-              >Dashboard</a>
+              >{{ $t('dashboard.title') }}</a>
               <a
                 :href="github"
                 target="_blank"
@@ -75,6 +84,17 @@ const { title, github } = useAppConfig()
                   class="w-5 h-5 mr-1"
                 />
                 GitHub</a>
+              <Tabs v-model="currentLocale" class="md:ml-2 lg:ml-3">
+                <TabsList>
+                  <TabsTrigger
+                    v-for="locale in locales"
+                    :key="locale.code"
+                    :value="locale.code"
+                  >
+                    {{ locale.language }}
+                  </TabsTrigger>
+                </TabsList>
+              </Tabs>
               <span class="ml-1">
                 <SwitchTheme />
               </span>

--- a/components/login/index.vue
+++ b/components/login/index.vue
@@ -3,6 +3,8 @@ import { AlertCircle } from 'lucide-vue-next'
 import { toast } from 'vue-sonner'
 import { z } from 'zod'
 
+const { t } = useI18n()
+
 const LoginSchema = z.object({
   token: z.string().describe('SiteToken'),
 })
@@ -25,7 +27,7 @@ async function onSubmit(form) {
   }
   catch (e) {
     console.error(e)
-    toast.error('Login failed, please try again.', {
+    toast.error(t('login.failed'), {
       description: e.message,
     })
   }
@@ -36,10 +38,10 @@ async function onSubmit(form) {
   <Card class="w-full max-w-sm">
     <CardHeader>
       <CardTitle class="text-2xl">
-        Login
+        {{ $t('login.title') }}
       </CardTitle>
       <CardDescription>
-        Enter your site token to login.
+        {{ $t('login.description') }}
       </CardDescription>
     </CardHeader>
     <CardContent class="grid gap-4">
@@ -51,13 +53,13 @@ async function onSubmit(form) {
       >
         <Alert v-if="previewMode">
           <AlertCircle class="w-4 h-4" />
-          <AlertTitle>Tips</AlertTitle>
+          <AlertTitle>{{ $t('login.tips') }}</AlertTitle>
           <AlertDescription>
-            The site token for preview mode is <code class="font-mono text-green-500">SinkCool</code> .
+            {{ $t('login.preview_token') }} <code class="font-mono text-green-500">SinkCool</code> .
           </AlertDescription>
         </Alert>
         <Button class="w-full">
-          Login
+          {{ $t('login.submit') }}
         </Button>
       </AutoForm>
     </CardContent>

--- a/i18n/i18n.config.ts
+++ b/i18n/i18n.config.ts
@@ -1,0 +1,11 @@
+import { currentLocales } from './i18n'
+
+export default defineI18nConfig(() => {
+  return {
+    legacy: false,
+    availableLocales: currentLocales.map(l => l.code),
+    fallbackLocale: 'zh-CN',
+    fallbackWarn: true,
+    missingWarn: true,
+  }
+})

--- a/i18n/i18n.ts
+++ b/i18n/i18n.ts
@@ -1,0 +1,28 @@
+import type { LocaleObject } from '@nuxtjs/i18n'
+
+const locales: LocaleObject[] = [
+  {
+    code: 'zh-CN',
+    file: 'zh-CN.json',
+    name: '简体中文',
+    language: '简',
+  },
+  {
+    code: 'en-US',
+    file: 'en-US.json',
+    name: 'English',
+    language: 'En',
+  },
+]
+
+function buildLocales() {
+  const useLocales = Object.values(locales).reduce((acc, data) => {
+    acc.push(data)
+
+    return acc
+  }, <LocaleObject[]>[])
+
+  return useLocales.sort((a, b) => a.code.localeCompare(b.code))
+}
+
+export const currentLocales = buildLocales()

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -1,0 +1,161 @@
+{
+  "common": {
+    "i18n": "Multi Language",
+    "abbreviations": "En",
+    "current_language": "English",
+    "try_again": "Try again",
+    "cancel": "Cancel",
+    "continue": "Continue",
+    "close": "Close",
+    "save": "Save",
+    "edit": "Edit",
+    "delete": "Delete",
+    "delete_success": "Delete successful!",
+    "search": "Search"
+  },
+  "theme": {
+    "toggle": "Toggle theme",
+    "light": "Light",
+    "dark": "Dark",
+    "system": "System"
+  },
+  "login": {
+    "title": "Login",
+    "description": "Enter your site token to login",
+    "tips": "Tips",
+    "preview_token": "The site token for preview mode is",
+    "submit": "Login",
+    "failed": "Login failed, please try again"
+  },
+  "logout": {
+    "title": "LogOut?",
+    "confirm": "Are you sure you want to log out?",
+    "action": "LogOut"
+  },
+  "layouts": {
+    "footer": {
+      "copyright": "Products of HTML.ZONE",
+      "social": {
+        "email": "Email",
+        "telegram": "Telegram",
+        "blog": "Blog",
+        "twitter": "Twitter",
+        "mastodon": "Mastodon",
+        "github": "GitHub"
+      }
+    },
+    "header": {
+      "select_language": "Select Language"
+    }
+  },
+  "nav": {
+    "links": "Links",
+    "analysis": "Analysis"
+  },
+  "home": {
+    "features": {
+      "title": "Features",
+      "subtitle": "Simple and sufficient functionality",
+      "url_shortening": {
+        "title": "URL Shortening",
+        "description": "Compress your URLs to their minimal length"
+      },
+      "analytics": {
+        "title": "Analytics",
+        "description": "Monitor link analytics and gather insightful statistics"
+      },
+      "serverless": {
+        "title": "Serverless",
+        "description": "Deploy without the need for traditional servers"
+      },
+      "customizable_slug": {
+        "title": "Customizable Slug",
+        "description": "Support for personalized slugs and case sensitivity"
+      },
+      "ai_slug": {
+        "title": "AI Slug",
+        "description": "Leverage AI to generate slugs"
+      },
+      "link_expiration": {
+        "title": "Link Expiration",
+        "description": "Set expiration dates for your links"
+      }
+    },
+    "cta": {
+      "title": "Deployment immediately",
+      "description": "With just a few simple clicks, you can start deploying without any expenses",
+      "button": "Start Deploy"
+    },
+    "logos": {
+      "title": "Built with awesome technologies"
+    },
+    "twitter": {
+      "follow": "Follow me on X(Twitter)"
+    }
+  },
+  "dashboard": {
+    "title": "Dashboard",
+    "visits": "Visits",
+    "views": "Views",
+    "visitors": "Visitors",
+    "referers": "Referers",
+    "stats": "'s Stats",
+    "custom_date": "Custom Date",
+    "date": "Date",
+    "date_range": "Date Range",
+    "locations": "Locations",
+    "details": "Details",
+    "name": "Name",
+    "count": "Count",
+    "loading": "Loading",
+    "no_data": "No Data",
+    "none": "(None)",
+    "date_picker": {
+      "today": "Today",
+      "last_24h": "Last 24 hours",
+      "this_week": "This week",
+      "last_7d": "Last 7 days",
+      "this_month": "This month",
+      "last_30d": "Last 30 days",
+      "last_90d": "Last 90 days",
+      "custom": "Custom",
+      "custom_title": "Custom Date",
+      "single_date": "Date",
+      "date_range": "Date Range"
+    },
+    "metrics": {
+      "country": "Country",
+      "region": "Region",
+      "city": "City",
+      "referer": "Referer",
+      "slug": "Slug",
+      "language": "Language",
+      "timezone": "Timezone",
+      "device": "Device",
+      "deviceType": "Device Type",
+      "os": "OS",
+      "browser": "Browser",
+      "browserType": "Browser Type"
+    }
+  },
+  "links": {
+    "create": "Create Link",
+    "edit": "Edit Link",
+    "delete_confirm_title": "Are you absolutely sure?",
+    "delete_confirm_desc": "This action cannot be undone. This will really delete your link from servers.",
+    "delete_success": "Delete successful!",
+    "update_success": "Link updated successfully",
+    "create_success": "Link created successfully",
+    "preview_mode_tip": "The preview mode link is valid for up to 24 hours.",
+    "search_placeholder": "Search links...",
+    "no_results": "No links found.",
+    "group_title": "Links",
+    "copy_success": "Copy successful!",
+    "created_at": "Created At",
+    "updated_at": "Updated At",
+    "expires_at": "Expires At",
+    "no_more": "No more links",
+    "load_failed": "Loading links failed,",
+    "download_qr_code": "Download QR Code"
+  }
+}

--- a/i18n/locales/zh-CN.json
+++ b/i18n/locales/zh-CN.json
@@ -1,0 +1,161 @@
+{
+  "common": {
+    "i18n": "多语言",
+    "abbreviations": "简",
+    "current_language": "简体中文",
+    "try_again": "重试",
+    "cancel": "取消",
+    "continue": "继续",
+    "close": "关闭",
+    "save": "保存",
+    "edit": "编辑",
+    "delete": "删除",
+    "delete_success": "删除成功！",
+    "search": "搜索"
+  },
+  "theme": {
+    "toggle": "切换主题",
+    "light": "浅色",
+    "dark": "深色",
+    "system": "跟随系统"
+  },
+  "login": {
+    "title": "登录",
+    "description": "请输入站点令牌以登录",
+    "tips": "提示",
+    "preview_token": "预览模式的站点令牌是",
+    "submit": "登录",
+    "failed": "登录失败，请重试"
+  },
+  "logout": {
+    "title": "退出登录？",
+    "confirm": "确定要退出登录吗？",
+    "action": "退出登录"
+  },
+  "layouts": {
+    "footer": {
+      "copyright": "产品来自 HTML.ZONE",
+      "social": {
+        "email": "邮箱",
+        "telegram": "Telegram",
+        "blog": "博客",
+        "twitter": "Twitter",
+        "mastodon": "Mastodon",
+        "github": "GitHub"
+      }
+    },
+    "header": {
+      "select_language": "选择语言"
+    }
+  },
+  "nav": {
+    "links": "链接",
+    "analysis": "分析"
+  },
+  "home": {
+    "features": {
+      "title": "功能特点",
+      "subtitle": "简单而实用的功能",
+      "url_shortening": {
+        "title": "URL 缩短",
+        "description": "将您的 URL 压缩到最小长度"
+      },
+      "analytics": {
+        "title": "数据分析",
+        "description": "监控链接分析并收集有价值的统计数据"
+      },
+      "serverless": {
+        "title": "无服务器",
+        "description": "无需传统服务器即可部署"
+      },
+      "customizable_slug": {
+        "title": "自定义短链",
+        "description": "支持个性化短链和大小写敏感"
+      },
+      "ai_slug": {
+        "title": "AI 短链",
+        "description": "利用 AI 生成短链"
+      },
+      "link_expiration": {
+        "title": "链接过期",
+        "description": "为您的链接设置过期日期"
+      }
+    },
+    "cta": {
+      "title": "立即部署",
+      "description": "只需几个简单的点击，您就可以免费开始部署",
+      "button": "开始部署"
+    },
+    "logos": {
+      "title": "使用优秀的技术构建"
+    },
+    "twitter": {
+      "follow": "在 X(Twitter) 上关注我"
+    }
+  },
+  "dashboard": {
+    "title": "仪表盘",
+    "visits": "访问量",
+    "views": "浏览量",
+    "visitors": "访客数",
+    "referers": "引荐来源",
+    "stats": "的统计",
+    "custom_date": "自定义日期",
+    "date": "日期",
+    "date_range": "日期范围",
+    "locations": "地理位置",
+    "details": "详情",
+    "name": "名称",
+    "count": "数量",
+    "loading": "加载中",
+    "no_data": "暂无数据",
+    "none": "（无）",
+    "date_picker": {
+      "today": "今天",
+      "last_24h": "最近24小时",
+      "this_week": "本周",
+      "last_7d": "最近7天",
+      "this_month": "本月",
+      "last_30d": "最近30天",
+      "last_90d": "最近90天",
+      "custom": "自定义",
+      "custom_title": "自定义日期",
+      "single_date": "单个日期",
+      "date_range": "日期范围"
+    },
+    "metrics": {
+      "country": "国家",
+      "region": "地区",
+      "city": "城市",
+      "referer": "来源",
+      "slug": "短链",
+      "language": "语言",
+      "timezone": "时区",
+      "device": "设备",
+      "deviceType": "设备类型",
+      "os": "操作系统",
+      "browser": "浏览器",
+      "browserType": "浏览器类型"
+    }
+  },
+  "links": {
+    "create": "创建链接",
+    "edit": "编辑链接",
+    "delete_confirm_title": "确定要删除吗？",
+    "delete_confirm_desc": "此操作无法撤销。这将从服务器中永久删除您的链接。",
+    "delete_success": "删除成功！",
+    "update_success": "链接更新成功",
+    "create_success": "链接创建成功",
+    "preview_mode_tip": "预览模式下的链接最多有效24小时。",
+    "search_placeholder": "搜索链接...",
+    "no_results": "未找到链接。",
+    "group_title": "链接列表",
+    "copy_success": "复制成功！",
+    "created_at": "创建时间",
+    "updated_at": "更新时间",
+    "expires_at": "过期时间",
+    "no_more": "没有更多链接",
+    "load_failed": "加载链接失败,",
+    "download_qr_code": "下载二维码"
+  }
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,3 +1,5 @@
+import { currentLocales } from './i18n/i18n'
+
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
 
@@ -7,6 +9,7 @@ export default defineNuxtConfig({
     '@nuxt/eslint',
     '@nuxtjs/tailwindcss',
     '@nuxtjs/color-mode',
+    '@nuxtjs/i18n',
   ],
   devtools: { enabled: true },
 
@@ -68,5 +71,22 @@ export default defineNuxtConfig({
       stylistic: true,
       standalone: false,
     },
+  },
+
+  i18n: {
+    locales: currentLocales,
+    compilation: {
+      strictMessage: false,
+      escapeHtml: true,
+    },
+    lazy: true,
+    strategy: 'no_prefix',
+    detectBrowserLanguage: {
+      useCookie: true,
+      cookieKey: 'sink_i18n_redirected',
+      redirectOn: 'root',
+    },
+    baseUrl: '/',
+    defaultLocale: 'en-US',
   },
 })

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "vaul-vue": "^0.3.0",
     "vee-validate": "^4.15.0",
     "virtua": "^0.39.2",
+    "vue": "^3.5.13",
     "vue-sonner": "^1.3.0",
     "vue3-simple-icons": "^13.2.0",
     "zod": "^3.24.1"
@@ -48,6 +49,7 @@
     "@nuxt/eslint-config": "^0.7.4",
     "@nuxthub/core": "0.7.11",
     "@nuxtjs/color-mode": "^3.5.2",
+    "@nuxtjs/i18n": "^9.0.0",
     "@nuxtjs/tailwindcss": "^6.12.2",
     "@vueuse/integrations": "^12.2.0",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,16 +10,16 @@ importers:
     dependencies:
       '@number-flow/vue':
         specifier: ^0.3.3
-        version: 0.3.3(vue@3.4.38(typescript@5.7.2))
+        version: 0.3.3(vue@3.5.13(typescript@5.7.2))
       '@unovis/ts':
         specifier: ^1.5.0
         version: 1.5.0
       '@unovis/vue':
         specifier: ^1.5.0
-        version: 1.5.0(@unovis/ts@1.5.0)(vue@3.4.38(typescript@5.7.2))
+        version: 1.5.0(@unovis/ts@1.5.0)(vue@3.5.13(typescript@5.7.2))
       '@vee-validate/zod':
         specifier: ^4.15.0
-        version: 4.15.0(vue@3.4.38(typescript@5.7.2))(zod@3.24.1)
+        version: 4.15.0(vue@3.5.13(typescript@5.7.2))(zod@3.24.1)
       '@vueuse/core':
         specifier: ^12.2.0
         version: 12.2.0(typescript@5.7.2)
@@ -31,7 +31,7 @@ importers:
         version: 1.0.0
       lucide-vue-next:
         specifier: ^0.469.0
-        version: 0.469.0(vue@3.4.38(typescript@5.7.2))
+        version: 0.469.0(vue@3.5.13(typescript@5.7.2))
       mysql-bricks:
         specifier: ^1.1.2
         version: 1.1.2
@@ -46,19 +46,22 @@ importers:
         version: 1.6.0-rc.1
       radix-vue:
         specifier: ^1.9.11
-        version: 1.9.11(vue@3.4.38(typescript@5.7.2))
+        version: 1.9.11(vue@3.5.13(typescript@5.7.2))
       ua-parser-js:
         specifier: next
         version: 2.0.0-beta.3
       vaul-vue:
         specifier: ^0.3.0
-        version: 0.3.0(reka-ui@2.0.2(typescript@5.7.2)(vue@3.4.38(typescript@5.7.2)))(vue@3.4.38(typescript@5.7.2))
+        version: 0.3.0(reka-ui@2.0.2(typescript@5.7.2)(vue@3.5.13(typescript@5.7.2)))(vue@3.5.13(typescript@5.7.2))
       vee-validate:
         specifier: ^4.15.0
-        version: 4.15.0(vue@3.4.38(typescript@5.7.2))
+        version: 4.15.0(vue@3.5.13(typescript@5.7.2))
       virtua:
         specifier: ^0.39.2
-        version: 0.39.2(vue@3.4.38(typescript@5.7.2))
+        version: 0.39.2(vue@3.5.13(typescript@5.7.2))
+      vue:
+        specifier: ^3.5.13
+        version: 3.5.13(typescript@5.7.2)
       vue-sonner:
         specifier: ^1.3.0
         version: 1.3.0
@@ -84,6 +87,9 @@ importers:
       '@nuxtjs/color-mode':
         specifier: ^3.5.2
         version: 3.5.2(magicast@0.3.5)(rollup@4.18.0)
+      '@nuxtjs/i18n':
+        specifier: ^9.0.0
+        version: 9.2.1(@vue/compiler-dom@3.5.13)(eslint@9.17.0(jiti@2.4.2))(magicast@0.3.5)(rollup@4.18.0)(typescript@5.7.2)(vue@3.5.13(typescript@5.7.2))
       '@nuxtjs/tailwindcss':
         specifier: ^6.12.2
         version: 6.12.2(magicast@0.3.5)(rollup@4.18.0)
@@ -338,16 +344,8 @@ packages:
     resolution: {integrity: sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.24.7':
-    resolution: {integrity: sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.25.9':
     resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.24.7':
-    resolution: {integrity: sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.25.9':
@@ -373,11 +371,6 @@ packages:
   '@babel/highlight@7.24.7':
     resolution: {integrity: sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/parser@7.24.7':
-    resolution: {integrity: sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
 
   '@babel/parser@7.26.3':
     resolution: {integrity: sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==}
@@ -469,10 +462,6 @@ packages:
 
   '@babel/traverse@7.26.4':
     resolution: {integrity: sha512-fH+b7Y4p3yqvApJALCPJcwb0/XaOSgtK4pzV6WVjPR5GLFQBRI7pfoX2V2iM48NXvX07NUxxm1Vw98YjqTcU5w==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.24.7':
-    resolution: {integrity: sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.26.3':
@@ -1404,6 +1393,85 @@ packages:
   '@internationalized/number@3.5.3':
     resolution: {integrity: sha512-rd1wA3ebzlp0Mehj5YTuTI50AQEx80gWFyHcQu+u91/5NgdwBecO8BH6ipPfE+lmQ9d63vpB3H9SHoIUiupllw==}
 
+  '@intlify/bundle-utils@10.0.0':
+    resolution: {integrity: sha512-BR5yLOkF2dzrARTbAg7RGAIPcx9Aark7p1K/0O285F7rfzso9j2dsa+S4dA67clZ0rToZ10NSSTfbyUptVu7Bg==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      petite-vue-i18n: '*'
+      vue-i18n: '*'
+    peerDependenciesMeta:
+      petite-vue-i18n:
+        optional: true
+      vue-i18n:
+        optional: true
+
+  '@intlify/core-base@10.0.5':
+    resolution: {integrity: sha512-F3snDTQs0MdvnnyzTDTVkOYVAZOE/MHwRvF7mn7Jw1yuih4NrFYLNYIymGlLmq4HU2iIdzYsZ7f47bOcwY73XQ==}
+    engines: {node: '>= 16'}
+
+  '@intlify/core@10.0.5':
+    resolution: {integrity: sha512-wvjsNSpjulznpPs24ZmwvmcomUP6qvBvRt5YAplx5zaCqM7n5KbiZk4mlPl2GjPVYUIOLlyZb0CUFQ5UJB/DMA==}
+    engines: {node: '>= 16'}
+
+  '@intlify/h3@0.6.1':
+    resolution: {integrity: sha512-hFMcqWXCoFNZkraa+JF7wzByGdE0vGi8rUs7CTFrE4hE3X2u9QcelH8VRO8mPgJDH+TgatzvrVp6iZsWVluk2A==}
+    engines: {node: '>= 18'}
+
+  '@intlify/message-compiler@10.0.5':
+    resolution: {integrity: sha512-6GT1BJ852gZ0gItNZN2krX5QAmea+cmdjMvsWohArAZ3GmHdnNANEcF9JjPXAMRtQ6Ux5E269ymamg/+WU6tQA==}
+    engines: {node: '>= 16'}
+
+  '@intlify/message-compiler@11.0.0-rc.1':
+    resolution: {integrity: sha512-TGw2uBfuTFTegZf/BHtUQBEKxl7Q/dVGLoqRIdw8lFsp9g/53sYn5iD+0HxIzdYjbWL6BTJMXCPUHp9PxDTRPw==}
+    engines: {node: '>= 16'}
+
+  '@intlify/shared@10.0.5':
+    resolution: {integrity: sha512-bmsP4L2HqBF6i6uaMqJMcFBONVjKt+siGluRq4Ca4C0q7W2eMaVZr8iCgF9dKbcVXutftkC7D6z2SaSMmLiDyA==}
+    engines: {node: '>= 16'}
+
+  '@intlify/shared@11.0.0-rc.1':
+    resolution: {integrity: sha512-8tR1xe7ZEbkabTuE/tNhzpolygUn9OaYp9yuYAF4MgDNZg06C3Qny80bes2/e9/Wm3aVkPUlCw6WgU7mQd0yEg==}
+    engines: {node: '>= 16'}
+
+  '@intlify/shared@11.1.1':
+    resolution: {integrity: sha512-2kGiWoXaeV8HZlhU/Nml12oTbhv7j2ufsJ5vQaa0VTjzUmZVdd/nmKFRAOJ/FtjO90Qba5AnZDwsrY7ZND5udA==}
+    engines: {node: '>= 16'}
+
+  '@intlify/unplugin-vue-i18n@6.0.3':
+    resolution: {integrity: sha512-9ZDjBlhUHtgjRl23TVcgfJttgu8cNepwVhWvOv3mUMRDAhjW0pur1mWKEUKr1I8PNwE4Gvv2IQ1xcl4RL0nG0g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      petite-vue-i18n: '*'
+      vue: ^3.2.25
+      vue-i18n: '*'
+    peerDependenciesMeta:
+      petite-vue-i18n:
+        optional: true
+      vue-i18n:
+        optional: true
+
+  '@intlify/utils@0.13.0':
+    resolution: {integrity: sha512-8i3uRdAxCGzuHwfmHcVjeLQBtysQB2aXl/ojoagDut5/gY5lvWCQ2+cnl2TiqE/fXj/D8EhWG/SLKA7qz4a3QA==}
+    engines: {node: '>= 18'}
+
+  '@intlify/vue-i18n-extensions@8.0.0':
+    resolution: {integrity: sha512-w0+70CvTmuqbskWfzeYhn0IXxllr6mU+IeM2MU0M+j9OW64jkrvqY+pYFWrUnIIC9bEdij3NICruicwd5EgUuQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@intlify/shared': ^9.0.0 || ^10.0.0 || ^11.0.0
+      '@vue/compiler-dom': ^3.0.0
+      vue: ^3.0.0
+      vue-i18n: ^9.0.0 || ^10.0.0 || ^11.0.0
+    peerDependenciesMeta:
+      '@intlify/shared':
+        optional: true
+      '@vue/compiler-dom':
+        optional: true
+      vue:
+        optional: true
+      vue-i18n:
+        optional: true
+
   '@ioredis/commands@1.2.0':
     resolution: {integrity: sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==}
 
@@ -1482,6 +1550,11 @@ packages:
   '@mapbox/whoots-js@3.1.0':
     resolution: {integrity: sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==}
     engines: {node: '>=6.0.0'}
+
+  '@miyaneee/rollup-plugin-json5@1.2.0':
+    resolution: {integrity: sha512-JjTIaXZp9WzhUHpElrqPnl1AzBi/rvRs065F71+aTmlqvTMVkdbjZ8vfFl4nRlgJy+TPBw69ZK4pwFdmOAt4aA==}
+    peerDependencies:
+      rollup: ^1.20.0 || ^2.0.0 || ^3.0.0 || ^4.0.0
 
   '@netlify/functions@2.8.1':
     resolution: {integrity: sha512-+6wtYdoz0yE06dSa9XkP47tw5zm6g13QMeCwM3MmHx1vn8hzwFa51JtmfraprdkL7amvb7gaNM+OOhQU1h6T8A==}
@@ -1580,6 +1653,10 @@ packages:
     resolution: {integrity: sha512-Q7k11wDTLIbBgoTfRYNrciK7PvjKklewrKd5PRMJCpn9Lmuqkq59HErNfJXFrBKHsE3Ld0DB6WUtpPGOvWJZoQ==}
     engines: {node: '>=18.20.5'}
 
+  '@nuxt/kit@3.15.4':
+    resolution: {integrity: sha512-dr7I7eZOoRLl4uxdxeL2dQsH0OrbEiVPIyBHnBpA4co24CBnoJoF+JINuP9l3PAM3IhUzc5JIVq3/YY3lEc3Hw==}
+    engines: {node: '>=18.12.0'}
+
   '@nuxt/schema@3.12.4':
     resolution: {integrity: sha512-H7FwBV4ChssMaeiLyPdVLOLUa0326ebp3pNbJfGgFt7rSoKh1MmgjorecA8JMxOQZziy3w6EELf4+5cgLh/F1w==}
     engines: {node: ^14.18.0 || >=16.10.0}
@@ -1608,6 +1685,10 @@ packages:
 
   '@nuxtjs/color-mode@3.5.2':
     resolution: {integrity: sha512-cC6RfgZh3guHBMLLjrBB2Uti5eUoGM9KyauOaYS9ETmxNWBMTvpgjvSiSJp1OFljIXPIqVTJ3xtJpSNZiO3ZaA==}
+
+  '@nuxtjs/i18n@9.2.1':
+    resolution: {integrity: sha512-rSIZ0p97A/II5P1Rf5f7oboWvViQKU23rP4iOD0KrNpIDnmO796C1g+4ifTpMo38SskwVxdGVWqvcuxOJ/XmyA==}
+    engines: {node: ^14.16.0 || >=16.11.0}
 
   '@nuxtjs/tailwindcss@6.12.2':
     resolution: {integrity: sha512-qPJiFH67CkTj/2kBGBzqXihOD1rQXMsbVS4vdQvfBxOBLPfGhU1yw7AATdhPl2BBjO2krjJLuZj39t7dnDYOwg==}
@@ -1644,35 +1725,30 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-glibc@2.4.1':
     resolution: {integrity: sha512-BJ7mH985OADVLpbrzCLgrJ3TOpiZggE9FMblfO65PlOCdG++xJpKUJ0Aol74ZUIYfb8WsRlUdgrZxKkz3zXWYA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.4.1':
     resolution: {integrity: sha512-p4Xb7JGq3MLgAfYhslU2SjoV9G0kI0Xry0kuxeG/41UfpjHGOhv7UoUDAz/jb1u2elbhazy4rRBL8PegPJFBhA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.4.1':
     resolution: {integrity: sha512-s9O3fByZ/2pyYDPoLM6zt92yu6P4E39a03zvO0qCHOTjxmt3GHRMLuRZEWhWLASTMSrrnVNWdVI/+pUElJBBBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.4.1':
     resolution: {integrity: sha512-L2nZTYR1myLNST0O632g0Dx9LyMNHrn6TOt76sYxWLdff3cB22/GZX2UPtJnaqQPdCRoszoY5rcOj4oMTtp5fQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-wasm@2.4.1':
     resolution: {integrity: sha512-/ZR0RxqxU/xxDGzbzosMjh4W6NdYFMqq2nvo2b8SLi7rsl/4jkL8S5stIikorNkdR50oVDvqb/3JT05WM+CRRA==}
@@ -1776,6 +1852,15 @@ packages:
       rollup:
         optional: true
 
+  '@rollup/plugin-yaml@4.1.2':
+    resolution: {integrity: sha512-RpupciIeZMUqhgFE97ba0s98mOFS7CWzN3EJNhJkqSv9XLlWYtwVdtE6cDw6ASOF/sZVFS7kRJXftaqM2Vakdw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
   '@rollup/pluginutils@4.2.1':
     resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
     engines: {node: '>= 8.0.0'}
@@ -1852,115 +1937,96 @@ packages:
     resolution: {integrity: sha512-C/zbRYRXFjWvz9Z4haRxcTdnkPt1BtCkz+7RtBSuNmKzMzp3ZxdM28Mpccn6pt28/UWUCTXa+b0Mx1k3g6NOMA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.29.1':
     resolution: {integrity: sha512-Py5vFd5HWYN9zxBv3WMrLAXY3yYJ6Q/aVERoeUFwiDGiMOWsMs7FokXihSOaT/PMWUty/Pj60XDQndK3eAfE6A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.18.0':
     resolution: {integrity: sha512-l3m9ewPgjQSXrUMHg93vt0hYCGnrMOcUpTz6FLtbwljo2HluS4zTXFy2571YQbisTnfTKPZ01u/ukJdQTLGh9A==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.29.1':
     resolution: {integrity: sha512-RiWpGgbayf7LUcuSNIbahr0ys2YnEERD4gYdISA06wa0i8RALrnzflh9Wxii7zQJEB2/Eh74dX4y/sHKLWp5uQ==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.18.0':
     resolution: {integrity: sha512-rJ5D47d8WD7J+7STKdCUAgmQk49xuFrRi9pZkWoRD1UeSMakbcepWXPF8ycChBoAqs1pb2wzvbY6Q33WmN2ftw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-gnu@4.29.1':
     resolution: {integrity: sha512-Z80O+taYxTQITWMjm/YqNoe9d10OX6kDh8X5/rFCMuPqsKsSyDilvfg+vd3iXIqtfmp+cnfL1UrYirkaF8SBZA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.18.0':
     resolution: {integrity: sha512-be6Yx37b24ZwxQ+wOQXXLZqpq4jTckJhtGlWGZs68TgdKXJgw54lUUoFYrg6Zs/kjzAQwEwYbp8JxZVzZLRepQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.29.1':
     resolution: {integrity: sha512-fOHRtF9gahwJk3QVp01a/GqS4hBEZCV1oKglVVq13kcK3NeVlS4BwIFzOHDbmKzt3i0OuHG4zfRP0YoG5OF/rA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.29.1':
     resolution: {integrity: sha512-5a7q3tnlbcg0OodyxcAdrrCxFi0DgXJSoOuidFUzHZ2GixZXQs6Tc3CHmlvqKAmOs5eRde+JJxeIf9DonkmYkw==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.18.0':
     resolution: {integrity: sha512-hNVMQK+qrA9Todu9+wqrXOHxFiD5YmdEi3paj6vP02Kx1hjd2LLYR2eaN7DsEshg09+9uzWi2W18MJDlG0cxJA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.29.1':
     resolution: {integrity: sha512-9b4Mg5Yfz6mRnlSPIdROcfw1BU22FQxmfjlp/CShWwO3LilKQuMISMTtAu/bxmmrE6A902W2cZJuzx8+gJ8e9w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.18.0':
     resolution: {integrity: sha512-ROCM7i+m1NfdrsmvwSzoxp9HFtmKGHEqu5NNDiZWQtXLA8S5HBCkVvKAxJ8U+CVctHwV2Gb5VUaK7UAkzhDjlg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.29.1':
     resolution: {integrity: sha512-G5pn0NChlbRM8OJWpJFMX4/i8OEU538uiSv0P6roZcbpe/WfhEO+AT8SHVKfp8qhDQzaz7Q+1/ixMy7hBRidnQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.18.0':
     resolution: {integrity: sha512-0UyyRHyDN42QL+NbqevXIIUnKA47A+45WyasO+y2bGJ1mhQrfrtXUpTxCOrfxCR4esV3/RLYyucGVPiUsO8xjg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.29.1':
     resolution: {integrity: sha512-WM9lIkNdkhVwiArmLxFXpWndFGuOka4oJOZh8EP3Vb8q5lzdSCBuhjavJsw68Q9AKDGeOOIHYzYm4ZFvmWez5g==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.18.0':
     resolution: {integrity: sha512-xuglR2rBVHA5UsI8h8UbX4VJ470PtGCf5Vpswh7p2ukaqBGFTnsfzxUBetoWBWymHMxbIG0Cmx7Y9qDZzr648w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.29.1':
     resolution: {integrity: sha512-87xYCwb0cPGZFoGiErT1eDcssByaLX4fc0z2nRM6eMtV9njAfEE6OW3UniAoDhX4Iq5xQVpE6qO9aJbCFumKYQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.18.0':
     resolution: {integrity: sha512-LKaqQL9osY/ir2geuLVvRRs+utWUNilzdE90TpyoX0eNqPzWjRm14oMEE+YLve4k/NAqCdPkGYDaDF5Sw+xBfg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.29.1':
     resolution: {integrity: sha512-xufkSNppNOdVRCEC4WKvlR1FBDyqCSCpQeMMgv9ZyXqqtKBfkw1yfGMTUTs9Qsl6WQbJnsGboWCp7pJGkeMhKA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.18.0':
     resolution: {integrity: sha512-7J6TkZQFGo9qBKH0pk2cEVSRhJbL6MtfWxth7Y5YmZs57Pi+4x6c2dStAUvaQkHQLnEQv1jzBUW43GvZW8OFqA==}
@@ -2422,26 +2488,14 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@vue/compiler-core@3.4.38':
-    resolution: {integrity: sha512-8IQOTCWnLFqfHzOGm9+P8OPSEDukgg3Huc92qSG49if/xI2SAwLHQO2qaPQbjCWPBcQoO1WYfXfTACUrWV3c5A==}
-
   '@vue/compiler-core@3.5.13':
     resolution: {integrity: sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==}
-
-  '@vue/compiler-dom@3.4.38':
-    resolution: {integrity: sha512-Osc/c7ABsHXTsETLgykcOwIxFktHfGSUDkb05V61rocEfsFDcjDLH/IHJSNJP+/Sv9KeN2Lx1V6McZzlSb9EhQ==}
 
   '@vue/compiler-dom@3.5.13':
     resolution: {integrity: sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==}
 
-  '@vue/compiler-sfc@3.4.38':
-    resolution: {integrity: sha512-s5QfZ+9PzPh3T5H4hsQDJtI8x7zdJaew/dCGgqZ2630XdzaZ3AD8xGZfBqpT8oaD/p2eedd+pL8tD5vvt5ZYJQ==}
-
   '@vue/compiler-sfc@3.5.13':
     resolution: {integrity: sha512-6VdaljMpD82w6c2749Zhf5T9u5uLBWKnVue6XWxprDobftnletJ8+oel7sexFfM3qIxNmVE7LSFGTpv6obNyaQ==}
-
-  '@vue/compiler-ssr@3.4.38':
-    resolution: {integrity: sha512-YXznKFQ8dxYpAz9zLuVvfcXhc31FSPFDcqr0kyujbOwNhlmaNvL2QfIy+RZeJgSn5Fk54CWoEUeW+NVBAogGaw==}
 
   '@vue/compiler-ssr@3.5.13':
     resolution: {integrity: sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==}
@@ -2474,36 +2528,19 @@ packages:
       typescript:
         optional: true
 
-  '@vue/reactivity@3.4.38':
-    resolution: {integrity: sha512-4vl4wMMVniLsSYYeldAKzbk72+D3hUnkw9z8lDeJacTxAkXeDAP1uE9xr2+aKIN0ipOL8EG2GPouVTH6yF7Gnw==}
-
   '@vue/reactivity@3.5.13':
     resolution: {integrity: sha512-NaCwtw8o48B9I6L1zl2p41OHo/2Z4wqYGGIK1Khu5T7yxrn+ATOixn/Udn2m+6kZKB/J7cuT9DbWWhRxqixACg==}
-
-  '@vue/runtime-core@3.4.38':
-    resolution: {integrity: sha512-21z3wA99EABtuf+O3IhdxP0iHgkBs1vuoCAsCKLVJPEjpVqvblwBnTj42vzHRlWDCyxu9ptDm7sI2ZMcWrQqlA==}
 
   '@vue/runtime-core@3.5.13':
     resolution: {integrity: sha512-Fj4YRQ3Az0WTZw1sFe+QDb0aXCerigEpw418pw1HBUKFtnQHWzwojaukAs2X/c9DQz4MQ4bsXTGlcpGxU/RCIw==}
 
-  '@vue/runtime-dom@3.4.38':
-    resolution: {integrity: sha512-afZzmUreU7vKwKsV17H1NDThEEmdYI+GCAK/KY1U957Ig2NATPVjCROv61R19fjZNzMmiU03n79OMnXyJVN0UA==}
-
   '@vue/runtime-dom@3.5.13':
     resolution: {integrity: sha512-dLaj94s93NYLqjLiyFzVs9X6dWhTdAlEAciC3Moq7gzAc13VJUdCnjjRurNM6uTLFATRHexHCTu/Xp3eW6yoog==}
-
-  '@vue/server-renderer@3.4.38':
-    resolution: {integrity: sha512-NggOTr82FbPEkkUvBm4fTGcwUY8UuTsnWC/L2YZBmvaQ4C4Jl/Ao4HHTB+l7WnFCt5M/dN3l0XLuyjzswGYVCA==}
-    peerDependencies:
-      vue: 3.4.38
 
   '@vue/server-renderer@3.5.13':
     resolution: {integrity: sha512-wAi4IRJV/2SAW3htkTlB+dHeRmpTiVIK1OGLWV1yeStVSebSQQOwGwIq0D3ZIoBj2C2qpgz5+vX9iEBkTdk5YA==}
     peerDependencies:
       vue: 3.5.13
-
-  '@vue/shared@3.4.38':
-    resolution: {integrity: sha512-q0xCiLkuWWQLzVrecPb0RMsNWyxICOjPrcrwxTUEHb1fsnvni4dcuyG7RT/Ie7VPTvnjzIaWzRMUBsrqNj/hhw==}
 
   '@vue/shared@3.5.13':
     resolution: {integrity: sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==}
@@ -3007,6 +3044,10 @@ packages:
 
   consola@3.3.1:
     resolution: {integrity: sha512-GyKnPG3/I+a4RtJxgHquJXWr70g9I3c4NT3dvqh0LPHQP2nZFQBOBszb7a5u/pGzqr40AKplQA6UxM1BSynSXg==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  consola@3.4.0:
+    resolution: {integrity: sha512-EiPU8G6dQG0GFHNR8ljnZFki/8a+cQwEQ+7wpxdChl02Q8HXlwEZWD5lqAF8vC2sEC3Tehr8hy7vErz88LHyUA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
   console-control-strings@1.1.0:
@@ -3580,6 +3621,11 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
+  escodegen@2.1.0:
+    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
+    engines: {node: '>=6.0'}
+    hasBin: true
+
   eslint-compat-utils@0.5.1:
     resolution: {integrity: sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q==}
     engines: {node: '>=12'}
@@ -3767,6 +3813,11 @@ packages:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   esquery@1.6.0:
     resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
     engines: {node: '>=0.10'}
@@ -3846,6 +3897,14 @@ packages:
 
   fdir@6.4.2:
     resolution: {integrity: sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fdir@6.4.3:
+    resolution: {integrity: sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==}
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -4158,6 +4217,10 @@ packages:
     resolution: {integrity: sha512-lcX8PNQygAa22u/0BysEY8VhaFRzlOkvdlKczDPnJvrkJD1EuqzEky5VYYKM2iySIuaVIDv9N190DfSreSLw2A==}
     engines: {node: '>= 4'}
 
+  ignore@7.0.3:
+    resolution: {integrity: sha512-bAH5jbK/F3T3Jls4I0SO1hmPR0dKU0a7+SY6n1yzRtG54FLO8d6w/nxLFX2Nb7dBu6cCWXPaAME6cYqFUMmuCA==}
+    engines: {node: '>= 4'}
+
   image-meta@0.2.1:
     resolution: {integrity: sha512-K6acvFaelNxx8wc2VjbIzXKDVB0Khs0QT35U6NkGfTdCmjLNcO2945m7RFNR9/RPVFm48hq7QPzK8uGH18HCGw==}
 
@@ -4261,6 +4324,9 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-https@4.0.0:
+    resolution: {integrity: sha512-FeMLiqf8E5g6SdiVJsPcNZX8k4h2fBs1wp5Bb6uaNxn58ufK1axBqQZdmAQsqh0t9BuwFObybrdVJh6MKyPlyg==}
 
   is-inside-container@1.0.0:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
@@ -4493,6 +4559,10 @@ packages:
 
   local-pkg@0.5.1:
     resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
+    engines: {node: '>=14'}
+
+  local-pkg@1.1.0:
+    resolution: {integrity: sha512-xbZBuX6gYIWrlLmZG43aAVer4ocntYO09vPy9lxd6Ns8DnR4U7N+IIeDkubinqFOHHzoMlPxTxwo0jhE7oYjAw==}
     engines: {node: '>=14'}
 
   locate-path@5.0.0:
@@ -4809,6 +4879,9 @@ packages:
 
   mlly@1.7.3:
     resolution: {integrity: sha512-xUsx5n/mN0uQf4V548PKQ+YShA4/IW0KI1dZhrNrPCLG+xizETbHTkOa1f8/xut9JRPp8kQuMnz0oqwkTiLo/A==}
+
+  mlly@1.7.4:
+    resolution: {integrity: sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -5142,15 +5215,15 @@ packages:
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   pbf@3.2.1:
     resolution: {integrity: sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==}
     hasBin: true
 
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
-
-  picocolors@1.0.1:
-    resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -5181,6 +5254,9 @@ packages:
 
   pkg-types@1.2.1:
     resolution: {integrity: sha512-sQoqa8alT3nHjGuTjuKgOnvjo4cljkufdtLMnO2LBP/wRwuDlo1tkaEdMxCRhyGRPacv/ztlZgDPm2b7FAmEvw==}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -5403,10 +5479,6 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.4.41:
-    resolution: {integrity: sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.4.49:
     resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
     engines: {node: ^10 || ^12 || >=14}
@@ -5451,6 +5523,9 @@ packages:
 
   qrcode-generator@1.4.4:
     resolution: {integrity: sha512-HM7yY8O2ilqhmULxGMpcHSF1EhJJ9yBj8gvDEuZ6M+KGJ0YY2hKpnXvRD+hZPLrDVck3ExIGhmPtSdcjC+guuw==}
+
+  quansync@0.2.7:
+    resolution: {integrity: sha512-KZDFlN9/Si3CgKHZsIfLBsrjWKFjqu9KA0zDGJEQoQzPm5HWNDEFc2mkLeYUBBOwEJtxNBSMaNLE/GlvArIEfQ==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -5878,6 +5953,9 @@ packages:
   strip-literal@2.1.1:
     resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
 
+  strip-literal@3.0.0:
+    resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
+
   striptags@3.2.0:
     resolution: {integrity: sha512-g45ZOGzHDMe2bdYMdIvdAfCQkCTDMGBazSw1ypMowwGIee7ZQ5dU0rBJ8Jqgl+jAKIv4dbeE1jscZq9wid1Tkw==}
 
@@ -5998,16 +6076,16 @@ packages:
     resolution: {integrity: sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.12:
+    resolution: {integrity: sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==}
+    engines: {node: '>=12.0.0'}
+
   tinyglobby@0.2.6:
     resolution: {integrity: sha512-NbBoFBpqfcgd1tCiO8Lkfdk+xrA7mlLR9zgvZcZWQQwU63XAfUePyd6wZBaU93Hqw347lHnwFzttAkemHzzz4g==}
     engines: {node: '>=12.0.0'}
 
   tinyqueue@2.0.3:
     resolution: {integrity: sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==}
-
-  to-fast-properties@2.0.0:
-    resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
-    engines: {node: '>=4'}
 
   to-px@1.1.0:
     resolution: {integrity: sha512-bfg3GLYrGoEzrGoE05TAL/Uw+H/qrf2ptr9V3W7U0lkjjyYnIfgxmVLUfhQ1hZpIQwin81uxhDjvUkDYsC0xWw==}
@@ -6027,6 +6105,10 @@ packages:
   topojson-client@3.1.0:
     resolution: {integrity: sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==}
     hasBin: true
+
+  tosource@2.0.0-alpha.3:
+    resolution: {integrity: sha512-KAB2lrSS48y91MzFPFuDg4hLbvDiyTjOVgaK7Erw+5AmZXNq4sFRVn8r6yxSLuNs15PaokrDRpS61ERY9uZOug==}
+    engines: {node: '>=10'}
 
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
@@ -6133,6 +6215,10 @@ packages:
   unimport@3.14.5:
     resolution: {integrity: sha512-tn890SwFFZxqaJSKQPPd+yygfKSATbM8BZWW1aCR2TJBTs1SDrmLamBueaFtYsGjHtQaRgqEbQflOjN2iW12gA==}
 
+  unimport@4.1.2:
+    resolution: {integrity: sha512-oVUL7PSlyVV3QRhsdcyYEMaDX8HJyS/CnUonEJTYA3//bWO+o/4gG8F7auGWWWkrrxBQBYOO8DKe+C53ktpRXw==}
+    engines: {node: '>=18.12.0'}
+
   unist-util-is@6.0.0:
     resolution: {integrity: sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==}
 
@@ -6148,6 +6234,10 @@ packages:
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
+
+  unplugin-utils@0.2.4:
+    resolution: {integrity: sha512-8U/MtpkPkkk3Atewj1+RcKIjb5WBimZ/WSLhhR3w6SsIj8XJuKTacSP8g+2JhfSGw0Cb125Y+2zA/IzJZDVbhA==}
+    engines: {node: '>=18.12.0'}
 
   unplugin-vue-router@0.10.9:
     resolution: {integrity: sha512-DXmC0GMcROOnCmN56GRvi1bkkG1BnVs4xJqNvucBUeZkmB245URvtxOfbo3H6q4SOUQQbLPYWd6InzvjRh363A==}
@@ -6171,6 +6261,10 @@ packages:
 
   unplugin@2.1.0:
     resolution: {integrity: sha512-us4j03/499KhbGP8BU7Hrzrgseo+KdfJYWcbcajCOqsAyb8Gk0Yn2kiUIcZISYCb1JFaZfIuG3b42HmguVOKCQ==}
+    engines: {node: '>=18.12.0'}
+
+  unplugin@2.2.0:
+    resolution: {integrity: sha512-m1ekpSwuOT5hxkJeZGRxO7gXbXT3gF26NjQ7GdVHoLoF8/nopLcd/QfPigpCy7i51oFHiRJg/CyHhj4vs2+KGw==}
     engines: {node: '>=18.12.0'}
 
   unstorage@1.14.1:
@@ -6449,6 +6543,12 @@ packages:
     peerDependencies:
       eslint: '>=6.0.0'
 
+  vue-i18n@10.0.5:
+    resolution: {integrity: sha512-9/gmDlCblz3i8ypu/afiIc/SUIfTTE1mr0mZhb9pk70xo2csHAM9mp2gdQ3KD2O0AM3Hz/5ypb+FycTj/lHlPQ==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      vue: ^3.0.0
+
   vue-router@4.5.0:
     resolution: {integrity: sha512-HDuk+PuH5monfNuY+ct49mNmkCRK4xJAV9Ts4z9UFc4rzdDnxQLyCMGGc8pKhZhHTVzfanpNwB/lwqevcBwI4w==}
     peerDependencies:
@@ -6465,14 +6565,6 @@ packages:
 
   vue3-simple-icons@13.2.0:
     resolution: {integrity: sha512-RCAr9gCQEDtHbQZ5xBPXm4+y6RWUZkER3yimb/XgJlAwK0UuwecTLw3kGXHvemfaCCSDBO3PqyPryIXHyZMgWw==}
-
-  vue@3.4.38:
-    resolution: {integrity: sha512-f0ZgN+mZ5KFgVv9wz0f4OgVKukoXtS3nwET4c2vLBGQR50aI8G0cqbFtLlX9Yiyg3LFGBitruPHt2PxwTduJEw==}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   vue@3.5.13:
     resolution: {integrity: sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==}
@@ -6939,11 +7031,7 @@ snapshots:
     dependencies:
       '@babel/types': 7.26.3
 
-  '@babel/helper-string-parser@7.24.7': {}
-
   '@babel/helper-string-parser@7.25.9': {}
-
-  '@babel/helper-validator-identifier@7.24.7': {}
 
   '@babel/helper-validator-identifier@7.25.9': {}
 
@@ -6967,10 +7055,6 @@ snapshots:
       chalk: 2.4.2
       js-tokens: 4.0.0
       picocolors: 1.1.1
-
-  '@babel/parser@7.24.7':
-    dependencies:
-      '@babel/types': 7.24.7
 
   '@babel/parser@7.26.3':
     dependencies:
@@ -7087,12 +7171,6 @@ snapshots:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/types@7.24.7':
-    dependencies:
-      '@babel/helper-string-parser': 7.24.7
-      '@babel/helper-validator-identifier': 7.24.7
-      to-fast-properties: 2.0.0
 
   '@babel/types@7.26.3':
     dependencies:
@@ -7676,20 +7754,20 @@ snapshots:
 
   '@floating-ui/utils@0.2.9': {}
 
-  '@floating-ui/vue@1.1.1(vue@3.4.38(typescript@5.7.2))':
+  '@floating-ui/vue@1.1.1(vue@3.5.13(typescript@5.7.2))':
     dependencies:
       '@floating-ui/dom': 1.6.7
       '@floating-ui/utils': 0.2.4
-      vue-demi: 0.14.10(vue@3.4.38(typescript@5.7.2))
+      vue-demi: 0.14.10(vue@3.5.13(typescript@5.7.2))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@floating-ui/vue@1.1.6(vue@3.4.38(typescript@5.7.2))':
+  '@floating-ui/vue@1.1.6(vue@3.5.13(typescript@5.7.2))':
     dependencies:
       '@floating-ui/dom': 1.6.13
       '@floating-ui/utils': 0.2.9
-      vue-demi: 0.14.10(vue@3.4.38(typescript@5.7.2))
+      vue-demi: 0.14.10(vue@3.5.13(typescript@5.7.2))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -7714,6 +7792,89 @@ snapshots:
   '@internationalized/number@3.5.3':
     dependencies:
       '@swc/helpers': 0.5.11
+
+  '@intlify/bundle-utils@10.0.0(vue-i18n@10.0.5(vue@3.5.13(typescript@5.7.2)))':
+    dependencies:
+      '@intlify/message-compiler': 11.0.0-rc.1
+      '@intlify/shared': 11.0.0-rc.1
+      acorn: 8.14.0
+      escodegen: 2.1.0
+      estree-walker: 2.0.2
+      jsonc-eslint-parser: 2.4.0
+      mlly: 1.7.3
+      source-map-js: 1.2.1
+      yaml-eslint-parser: 1.2.3
+    optionalDependencies:
+      vue-i18n: 10.0.5(vue@3.5.13(typescript@5.7.2))
+
+  '@intlify/core-base@10.0.5':
+    dependencies:
+      '@intlify/message-compiler': 10.0.5
+      '@intlify/shared': 10.0.5
+
+  '@intlify/core@10.0.5':
+    dependencies:
+      '@intlify/core-base': 10.0.5
+      '@intlify/shared': 10.0.5
+
+  '@intlify/h3@0.6.1':
+    dependencies:
+      '@intlify/core': 10.0.5
+      '@intlify/utils': 0.13.0
+
+  '@intlify/message-compiler@10.0.5':
+    dependencies:
+      '@intlify/shared': 10.0.5
+      source-map-js: 1.2.1
+
+  '@intlify/message-compiler@11.0.0-rc.1':
+    dependencies:
+      '@intlify/shared': 11.0.0-rc.1
+      source-map-js: 1.2.1
+
+  '@intlify/shared@10.0.5': {}
+
+  '@intlify/shared@11.0.0-rc.1': {}
+
+  '@intlify/shared@11.1.1': {}
+
+  '@intlify/unplugin-vue-i18n@6.0.3(@vue/compiler-dom@3.5.13)(eslint@9.17.0(jiti@2.4.2))(rollup@4.18.0)(typescript@5.7.2)(vue-i18n@10.0.5(vue@3.5.13(typescript@5.7.2)))(vue@3.5.13(typescript@5.7.2))':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.17.0(jiti@2.4.2))
+      '@intlify/bundle-utils': 10.0.0(vue-i18n@10.0.5(vue@3.5.13(typescript@5.7.2)))
+      '@intlify/shared': 11.1.1
+      '@intlify/vue-i18n-extensions': 8.0.0(@intlify/shared@11.1.1)(@vue/compiler-dom@3.5.13)(vue-i18n@10.0.5(vue@3.5.13(typescript@5.7.2)))(vue@3.5.13(typescript@5.7.2))
+      '@rollup/pluginutils': 5.1.4(rollup@4.18.0)
+      '@typescript-eslint/scope-manager': 8.18.2
+      '@typescript-eslint/typescript-estree': 8.18.2(typescript@5.7.2)
+      debug: 4.4.0
+      fast-glob: 3.3.2
+      js-yaml: 4.1.0
+      json5: 2.2.3
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+      unplugin: 1.16.0
+      vue: 3.5.13(typescript@5.7.2)
+    optionalDependencies:
+      vue-i18n: 10.0.5(vue@3.5.13(typescript@5.7.2))
+    transitivePeerDependencies:
+      - '@vue/compiler-dom'
+      - eslint
+      - rollup
+      - supports-color
+      - typescript
+
+  '@intlify/utils@0.13.0': {}
+
+  '@intlify/vue-i18n-extensions@8.0.0(@intlify/shared@11.1.1)(@vue/compiler-dom@3.5.13)(vue-i18n@10.0.5(vue@3.5.13(typescript@5.7.2)))(vue@3.5.13(typescript@5.7.2))':
+    dependencies:
+      '@babel/parser': 7.26.3
+    optionalDependencies:
+      '@intlify/shared': 11.1.1
+      '@vue/compiler-dom': 3.5.13
+      vue: 3.5.13(typescript@5.7.2)
+      vue-i18n: 10.0.5(vue@3.5.13(typescript@5.7.2))
 
   '@ioredis/commands@1.2.0': {}
 
@@ -7811,6 +7972,12 @@ snapshots:
 
   '@mapbox/whoots-js@3.1.0': {}
 
+  '@miyaneee/rollup-plugin-json5@1.2.0(rollup@4.18.0)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.4(rollup@4.18.0)
+      json5: 2.2.3
+      rollup: 4.18.0
+
   '@netlify/functions@2.8.1':
     dependencies:
       '@netlify/serverless-functions-api': 1.19.1
@@ -7846,11 +8013,11 @@ snapshots:
       '@nodelib/fs.scandir': 3.0.0
       fastq: 1.17.1
 
-  '@number-flow/vue@0.3.3(vue@3.4.38(typescript@5.7.2))':
+  '@number-flow/vue@0.3.3(vue@3.5.13(typescript@5.7.2))':
     dependencies:
       esm-env: 1.2.1
       number-flow: 0.4.2
-      vue: 3.4.38(typescript@5.7.2)
+      vue: 3.5.13(typescript@5.7.2)
 
   '@nuxt/devalue@2.0.2': {}
 
@@ -8071,6 +8238,32 @@ snapshots:
       - rollup
       - supports-color
 
+  '@nuxt/kit@3.15.4(magicast@0.3.5)':
+    dependencies:
+      c12: 2.0.1(magicast@0.3.5)
+      consola: 3.4.0
+      defu: 6.1.4
+      destr: 2.0.3
+      globby: 14.0.2
+      ignore: 7.0.3
+      jiti: 2.4.2
+      klona: 2.0.6
+      knitwork: 1.2.0
+      mlly: 1.7.4
+      ohash: 1.1.4
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      scule: 1.3.0
+      semver: 7.6.3
+      std-env: 3.8.0
+      ufo: 1.5.4
+      unctx: 2.4.1
+      unimport: 4.1.2
+      untyped: 1.5.2
+    transitivePeerDependencies:
+      - magicast
+      - supports-color
+
   '@nuxt/schema@3.12.4(rollup@4.18.0)':
     dependencies:
       compatx: 0.1.8
@@ -8263,6 +8456,41 @@ snapshots:
       - rollup
       - supports-color
 
+  '@nuxtjs/i18n@9.2.1(@vue/compiler-dom@3.5.13)(eslint@9.17.0(jiti@2.4.2))(magicast@0.3.5)(rollup@4.18.0)(typescript@5.7.2)(vue@3.5.13(typescript@5.7.2))':
+    dependencies:
+      '@intlify/h3': 0.6.1
+      '@intlify/shared': 10.0.5
+      '@intlify/unplugin-vue-i18n': 6.0.3(@vue/compiler-dom@3.5.13)(eslint@9.17.0(jiti@2.4.2))(rollup@4.18.0)(typescript@5.7.2)(vue-i18n@10.0.5(vue@3.5.13(typescript@5.7.2)))(vue@3.5.13(typescript@5.7.2))
+      '@intlify/utils': 0.13.0
+      '@miyaneee/rollup-plugin-json5': 1.2.0(rollup@4.18.0)
+      '@nuxt/kit': 3.15.4(magicast@0.3.5)
+      '@rollup/plugin-yaml': 4.1.2(rollup@4.18.0)
+      '@vue/compiler-sfc': 3.5.13
+      debug: 4.4.0
+      defu: 6.1.4
+      estree-walker: 3.0.3
+      is-https: 4.0.0
+      knitwork: 1.2.0
+      magic-string: 0.30.17
+      mlly: 1.7.3
+      pathe: 1.1.2
+      scule: 1.3.0
+      sucrase: 3.35.0
+      ufo: 1.5.4
+      unplugin: 1.16.0
+      unplugin-vue-router: 0.10.9(rollup@4.18.0)(vue-router@4.5.0(vue@3.5.13(typescript@5.7.2)))(vue@3.5.13(typescript@5.7.2))
+      vue-i18n: 10.0.5(vue@3.5.13(typescript@5.7.2))
+      vue-router: 4.5.0(vue@3.5.13(typescript@5.7.2))
+    transitivePeerDependencies:
+      - '@vue/compiler-dom'
+      - eslint
+      - magicast
+      - petite-vue-i18n
+      - rollup
+      - supports-color
+      - typescript
+      - vue
+
   '@nuxtjs/tailwindcss@6.12.2(magicast@0.3.5)(rollup@4.18.0)':
     dependencies:
       '@nuxt/kit': 3.15.0(magicast@0.3.5)(rollup@4.18.0)
@@ -8409,6 +8637,14 @@ snapshots:
       serialize-javascript: 6.0.2
       smob: 1.5.0
       terser: 5.31.0
+    optionalDependencies:
+      rollup: 4.18.0
+
+  '@rollup/plugin-yaml@4.1.2(rollup@4.18.0)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.4(rollup@4.18.0)
+      js-yaml: 4.1.0
+      tosource: 2.0.0-alpha.3
     optionalDependencies:
       rollup: 4.18.0
 
@@ -8560,15 +8796,15 @@ snapshots:
 
   '@tanstack/virtual-core@3.8.1': {}
 
-  '@tanstack/vue-virtual@3.13.2(vue@3.4.38(typescript@5.7.2))':
+  '@tanstack/vue-virtual@3.13.2(vue@3.5.13(typescript@5.7.2))':
     dependencies:
       '@tanstack/virtual-core': 3.13.2
-      vue: 3.4.38(typescript@5.7.2)
+      vue: 3.5.13(typescript@5.7.2)
 
-  '@tanstack/vue-virtual@3.8.1(vue@3.4.38(typescript@5.7.2))':
+  '@tanstack/vue-virtual@3.8.1(vue@3.5.13(typescript@5.7.2))':
     dependencies:
       '@tanstack/virtual-core': 3.8.1
-      vue: 3.4.38(typescript@5.7.2)
+      vue: 3.5.13(typescript@5.7.2)
 
   '@trysound/sax@0.2.0': {}
 
@@ -8985,17 +9221,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@unovis/vue@1.5.0(@unovis/ts@1.5.0)(vue@3.4.38(typescript@5.7.2))':
+  '@unovis/vue@1.5.0(@unovis/ts@1.5.0)(vue@3.5.13(typescript@5.7.2))':
     dependencies:
       '@unovis/ts': 1.5.0
-      vue: 3.4.38(typescript@5.7.2)
+      vue: 3.5.13(typescript@5.7.2)
 
   '@uploadthing/mime-types@0.2.10': {}
 
-  '@vee-validate/zod@4.15.0(vue@3.4.38(typescript@5.7.2))(zod@3.24.1)':
+  '@vee-validate/zod@4.15.0(vue@3.5.13(typescript@5.7.2))(zod@3.24.1)':
     dependencies:
       type-fest: 4.18.2
-      vee-validate: 4.15.0(vue@3.4.38(typescript@5.7.2))
+      vee-validate: 4.15.0(vue@3.5.13(typescript@5.7.2))
       zod: 3.24.1
     transitivePeerDependencies:
       - vue
@@ -9129,14 +9365,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vue/compiler-core@3.4.38':
-    dependencies:
-      '@babel/parser': 7.24.7
-      '@vue/shared': 3.4.38
-      entities: 4.5.0
-      estree-walker: 2.0.2
-      source-map-js: 1.2.0
-
   '@vue/compiler-core@3.5.13':
     dependencies:
       '@babel/parser': 7.26.3
@@ -9145,27 +9373,10 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.0
 
-  '@vue/compiler-dom@3.4.38':
-    dependencies:
-      '@vue/compiler-core': 3.4.38
-      '@vue/shared': 3.4.38
-
   '@vue/compiler-dom@3.5.13':
     dependencies:
       '@vue/compiler-core': 3.5.13
       '@vue/shared': 3.5.13
-
-  '@vue/compiler-sfc@3.4.38':
-    dependencies:
-      '@babel/parser': 7.24.7
-      '@vue/compiler-core': 3.4.38
-      '@vue/compiler-dom': 3.4.38
-      '@vue/compiler-ssr': 3.4.38
-      '@vue/shared': 3.4.38
-      estree-walker: 2.0.2
-      magic-string: 0.30.11
-      postcss: 8.4.41
-      source-map-js: 1.2.0
 
   '@vue/compiler-sfc@3.5.13':
     dependencies:
@@ -9175,14 +9386,9 @@ snapshots:
       '@vue/compiler-ssr': 3.5.13
       '@vue/shared': 3.5.13
       estree-walker: 2.0.2
-      magic-string: 0.30.11
+      magic-string: 0.30.17
       postcss: 8.4.49
-      source-map-js: 1.2.0
-
-  '@vue/compiler-ssr@3.4.38':
-    dependencies:
-      '@vue/compiler-dom': 3.4.38
-      '@vue/shared': 3.4.38
+      source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.13':
     dependencies:
@@ -9239,30 +9445,14 @@ snapshots:
     optionalDependencies:
       typescript: 5.7.2
 
-  '@vue/reactivity@3.4.38':
-    dependencies:
-      '@vue/shared': 3.4.38
-
   '@vue/reactivity@3.5.13':
     dependencies:
       '@vue/shared': 3.5.13
-
-  '@vue/runtime-core@3.4.38':
-    dependencies:
-      '@vue/reactivity': 3.4.38
-      '@vue/shared': 3.4.38
 
   '@vue/runtime-core@3.5.13':
     dependencies:
       '@vue/reactivity': 3.5.13
       '@vue/shared': 3.5.13
-
-  '@vue/runtime-dom@3.4.38':
-    dependencies:
-      '@vue/reactivity': 3.4.38
-      '@vue/runtime-core': 3.4.38
-      '@vue/shared': 3.4.38
-      csstype: 3.1.3
 
   '@vue/runtime-dom@3.5.13':
     dependencies:
@@ -9271,28 +9461,20 @@ snapshots:
       '@vue/shared': 3.5.13
       csstype: 3.1.3
 
-  '@vue/server-renderer@3.4.38(vue@3.4.38(typescript@5.7.2))':
-    dependencies:
-      '@vue/compiler-ssr': 3.4.38
-      '@vue/shared': 3.4.38
-      vue: 3.4.38(typescript@5.7.2)
-
   '@vue/server-renderer@3.5.13(vue@3.5.13(typescript@5.7.2))':
     dependencies:
       '@vue/compiler-ssr': 3.5.13
       '@vue/shared': 3.5.13
       vue: 3.5.13(typescript@5.7.2)
 
-  '@vue/shared@3.4.38': {}
-
   '@vue/shared@3.5.13': {}
 
-  '@vueuse/core@10.11.1(vue@3.4.38(typescript@5.7.2))':
+  '@vueuse/core@10.11.1(vue@3.5.13(typescript@5.7.2))':
     dependencies:
       '@types/web-bluetooth': 0.0.20
       '@vueuse/metadata': 10.11.1
-      '@vueuse/shared': 10.11.1(vue@3.4.38(typescript@5.7.2))
-      vue-demi: 0.14.10(vue@3.4.38(typescript@5.7.2))
+      '@vueuse/shared': 10.11.1(vue@3.5.13(typescript@5.7.2))
+      vue-demi: 0.14.10(vue@3.5.13(typescript@5.7.2))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -9331,9 +9513,9 @@ snapshots:
 
   '@vueuse/metadata@12.7.0': {}
 
-  '@vueuse/shared@10.11.1(vue@3.4.38(typescript@5.7.2))':
+  '@vueuse/shared@10.11.1(vue@3.5.13(typescript@5.7.2))':
     dependencies:
-      vue-demi: 0.14.10(vue@3.4.38(typescript@5.7.2))
+      vue-demi: 0.14.10(vue@3.5.13(typescript@5.7.2))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -9785,6 +9967,8 @@ snapshots:
   consola@3.2.3: {}
 
   consola@3.3.1: {}
+
+  consola@3.4.0: {}
 
   console-control-strings@1.1.0: {}
 
@@ -10417,6 +10601,14 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
+  escodegen@2.1.0:
+    dependencies:
+      esprima: 4.0.1
+      estraverse: 5.3.0
+      esutils: 2.0.3
+    optionalDependencies:
+      source-map: 0.6.1
+
   eslint-compat-utils@0.5.1(eslint@9.17.0(jiti@2.4.2)):
     dependencies:
       eslint: 9.17.0(jiti@2.4.2)
@@ -10714,6 +10906,8 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.12.1)
       eslint-visitor-keys: 3.4.3
 
+  esprima@4.0.1: {}
+
   esquery@1.6.0:
     dependencies:
       estraverse: 5.3.0
@@ -10798,6 +10992,10 @@ snapshots:
       reusify: 1.0.4
 
   fdir@6.4.2(picomatch@4.0.2):
+    optionalDependencies:
+      picomatch: 4.0.2
+
+  fdir@6.4.3(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
 
@@ -11132,6 +11330,8 @@ snapshots:
 
   ignore@7.0.0: {}
 
+  ignore@7.0.3: {}
+
   image-meta@0.2.1: {}
 
   import-fresh@3.3.0:
@@ -11225,6 +11425,8 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-https@4.0.0: {}
 
   is-inside-container@1.0.0:
     dependencies:
@@ -11505,6 +11707,12 @@ snapshots:
       mlly: 1.7.3
       pkg-types: 1.2.1
 
+  local-pkg@1.1.0:
+    dependencies:
+      mlly: 1.7.4
+      pkg-types: 1.3.1
+      quansync: 0.2.7
+
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
@@ -11549,9 +11757,9 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lucide-vue-next@0.469.0(vue@3.4.38(typescript@5.7.2)):
+  lucide-vue-next@0.469.0(vue@3.5.13(typescript@5.7.2)):
     dependencies:
-      vue: 3.4.38(typescript@5.7.2)
+      vue: 3.5.13(typescript@5.7.2)
 
   magic-string-ast@0.6.3:
     dependencies:
@@ -12009,6 +12217,13 @@ snapshots:
       pkg-types: 1.2.1
       ufo: 1.5.4
 
+  mlly@1.7.4:
+    dependencies:
+      acorn: 8.14.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.5.4
+
   mri@1.2.0: {}
 
   mrmime@2.0.0: {}
@@ -12269,7 +12484,7 @@ snapshots:
       vue: 3.5.13(typescript@5.7.2)
       vue-bundle-renderer: 2.1.0
       vue-devtools-stub: 0.1.0
-      vue-router: 4.5.0(vue@3.4.38(typescript@5.7.2))
+      vue-router: 4.5.0(vue@3.5.13(typescript@5.7.2))
     optionalDependencies:
       '@parcel/watcher': 2.4.1
       '@types/node': 20.12.11
@@ -12506,14 +12721,14 @@ snapshots:
 
   pathe@1.1.2: {}
 
+  pathe@2.0.3: {}
+
   pbf@3.2.1:
     dependencies:
       ieee754: 1.2.1
       resolve-protobuf-schema: 2.1.0
 
   perfect-debounce@1.0.0: {}
-
-  picocolors@1.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -12538,6 +12753,12 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.7.3
       pathe: 1.1.2
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.7.4
+      pathe: 2.0.3
 
   pluralize@8.0.0: {}
 
@@ -12746,12 +12967,6 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.4.41:
-    dependencies:
-      nanoid: 3.3.7
-      picocolors: 1.0.1
-      source-map-js: 1.2.0
-
   postcss@8.4.49:
     dependencies:
       nanoid: 3.3.7
@@ -12787,26 +13002,28 @@ snapshots:
 
   qrcode-generator@1.4.4: {}
 
+  quansync@0.2.7: {}
+
   queue-microtask@1.2.3: {}
 
   queue-tick@1.0.1: {}
 
   quickselect@2.0.0: {}
 
-  radix-vue@1.9.11(vue@3.4.38(typescript@5.7.2)):
+  radix-vue@1.9.11(vue@3.5.13(typescript@5.7.2)):
     dependencies:
       '@floating-ui/dom': 1.6.7
-      '@floating-ui/vue': 1.1.1(vue@3.4.38(typescript@5.7.2))
+      '@floating-ui/vue': 1.1.1(vue@3.5.13(typescript@5.7.2))
       '@internationalized/date': 3.5.4
       '@internationalized/number': 3.5.3
-      '@tanstack/vue-virtual': 3.8.1(vue@3.4.38(typescript@5.7.2))
-      '@vueuse/core': 10.11.1(vue@3.4.38(typescript@5.7.2))
-      '@vueuse/shared': 10.11.1(vue@3.4.38(typescript@5.7.2))
+      '@tanstack/vue-virtual': 3.8.1(vue@3.5.13(typescript@5.7.2))
+      '@vueuse/core': 10.11.1(vue@3.5.13(typescript@5.7.2))
+      '@vueuse/shared': 10.11.1(vue@3.5.13(typescript@5.7.2))
       aria-hidden: 1.2.4
       defu: 6.1.4
       fast-deep-equal: 3.1.3
       nanoid: 5.0.9
-      vue: 3.4.38(typescript@5.7.2)
+      vue: 3.5.13(typescript@5.7.2)
     transitivePeerDependencies:
       - '@vue/composition-api'
 
@@ -12897,19 +13114,19 @@ snapshots:
     dependencies:
       jsesc: 0.5.0
 
-  reka-ui@2.0.2(typescript@5.7.2)(vue@3.4.38(typescript@5.7.2)):
+  reka-ui@2.0.2(typescript@5.7.2)(vue@3.5.13(typescript@5.7.2)):
     dependencies:
       '@floating-ui/dom': 1.6.13
-      '@floating-ui/vue': 1.1.6(vue@3.4.38(typescript@5.7.2))
+      '@floating-ui/vue': 1.1.6(vue@3.5.13(typescript@5.7.2))
       '@internationalized/date': 3.5.4
       '@internationalized/number': 3.5.3
-      '@tanstack/vue-virtual': 3.13.2(vue@3.4.38(typescript@5.7.2))
+      '@tanstack/vue-virtual': 3.13.2(vue@3.5.13(typescript@5.7.2))
       '@vueuse/core': 12.7.0(typescript@5.7.2)
       '@vueuse/shared': 12.7.0(typescript@5.7.2)
       aria-hidden: 1.2.4
       defu: 6.1.4
       ohash: 1.1.4
-      vue: 3.4.38(typescript@5.7.2)
+      vue: 3.5.13(typescript@5.7.2)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - typescript
@@ -13280,6 +13497,10 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
+  strip-literal@3.0.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   striptags@3.2.0: {}
 
   stylehacks@7.0.4(postcss@8.4.49):
@@ -13435,14 +13656,17 @@ snapshots:
       fdir: 6.4.2(picomatch@4.0.2)
       picomatch: 4.0.2
 
+  tinyglobby@0.2.12:
+    dependencies:
+      fdir: 6.4.3(picomatch@4.0.2)
+      picomatch: 4.0.2
+
   tinyglobby@0.2.6:
     dependencies:
       fdir: 6.4.2(picomatch@4.0.2)
       picomatch: 4.0.2
 
   tinyqueue@2.0.3: {}
-
-  to-fast-properties@2.0.0: {}
 
   to-px@1.1.0:
     dependencies:
@@ -13461,6 +13685,8 @@ snapshots:
   topojson-client@3.1.0:
     dependencies:
       commander: 2.20.3
+
+  tosource@2.0.0-alpha.3: {}
 
   totalist@3.0.1: {}
 
@@ -13588,6 +13814,23 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
+  unimport@4.1.2:
+    dependencies:
+      acorn: 8.14.0
+      escape-string-regexp: 5.0.0
+      estree-walker: 3.0.3
+      local-pkg: 1.1.0
+      magic-string: 0.30.17
+      mlly: 1.7.4
+      pathe: 2.0.3
+      picomatch: 4.0.2
+      pkg-types: 1.3.1
+      scule: 1.3.0
+      strip-literal: 3.0.0
+      tinyglobby: 0.2.12
+      unplugin: 2.2.0
+      unplugin-utils: 0.2.4
+
   unist-util-is@6.0.0:
     dependencies:
       '@types/unist': 3.0.3
@@ -13609,6 +13852,11 @@ snapshots:
 
   universalify@2.0.1: {}
 
+  unplugin-utils@0.2.4:
+    dependencies:
+      pathe: 2.0.3
+      picomatch: 4.0.2
+
   unplugin-vue-router@0.10.9(rollup@4.18.0)(vue-router@4.5.0(vue@3.5.13(typescript@5.7.2)))(vue@3.5.13(typescript@5.7.2)):
     dependencies:
       '@babel/types': 7.26.3
@@ -13626,7 +13874,7 @@ snapshots:
       unplugin: 2.0.0-beta.1
       yaml: 2.6.1
     optionalDependencies:
-      vue-router: 4.5.0(vue@3.4.38(typescript@5.7.2))
+      vue-router: 4.5.0(vue@3.5.13(typescript@5.7.2))
     transitivePeerDependencies:
       - rollup
       - vue
@@ -13649,6 +13897,11 @@ snapshots:
       webpack-virtual-modules: 0.6.2
 
   unplugin@2.1.0:
+    dependencies:
+      acorn: 8.14.0
+      webpack-virtual-modules: 0.6.2
+
+  unplugin@2.2.0:
     dependencies:
       acorn: 8.14.0
       webpack-virtual-modules: 0.6.2
@@ -13740,23 +13993,23 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vaul-vue@0.3.0(reka-ui@2.0.2(typescript@5.7.2)(vue@3.4.38(typescript@5.7.2)))(vue@3.4.38(typescript@5.7.2)):
+  vaul-vue@0.3.0(reka-ui@2.0.2(typescript@5.7.2)(vue@3.5.13(typescript@5.7.2)))(vue@3.5.13(typescript@5.7.2)):
     dependencies:
-      '@vueuse/core': 10.11.1(vue@3.4.38(typescript@5.7.2))
-      reka-ui: 2.0.2(typescript@5.7.2)(vue@3.4.38(typescript@5.7.2))
-      vue: 3.4.38(typescript@5.7.2)
+      '@vueuse/core': 10.11.1(vue@3.5.13(typescript@5.7.2))
+      reka-ui: 2.0.2(typescript@5.7.2)(vue@3.5.13(typescript@5.7.2))
+      vue: 3.5.13(typescript@5.7.2)
     transitivePeerDependencies:
       - '@vue/composition-api'
 
-  vee-validate@4.15.0(vue@3.4.38(typescript@5.7.2)):
+  vee-validate@4.15.0(vue@3.5.13(typescript@5.7.2)):
     dependencies:
       '@vue/devtools-api': 7.6.8
       type-fest: 4.18.2
-      vue: 3.4.38(typescript@5.7.2)
+      vue: 3.5.13(typescript@5.7.2)
 
-  virtua@0.39.2(vue@3.4.38(typescript@5.7.2)):
+  virtua@0.39.2(vue@3.5.13(typescript@5.7.2)):
     optionalDependencies:
-      vue: 3.4.38(typescript@5.7.2)
+      vue: 3.5.13(typescript@5.7.2)
 
   vite-hot-client@0.2.4(vite@5.4.11(@types/node@20.12.11)(terser@5.31.0)):
     dependencies:
@@ -13879,9 +14132,9 @@ snapshots:
     dependencies:
       ufo: 1.5.4
 
-  vue-demi@0.14.10(vue@3.4.38(typescript@5.7.2)):
+  vue-demi@0.14.10(vue@3.5.13(typescript@5.7.2)):
     dependencies:
-      vue: 3.4.38(typescript@5.7.2)
+      vue: 3.5.13(typescript@5.7.2)
 
   vue-devtools-stub@0.1.0: {}
 
@@ -13898,10 +14151,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-router@4.5.0(vue@3.4.38(typescript@5.7.2)):
+  vue-i18n@10.0.5(vue@3.5.13(typescript@5.7.2)):
+    dependencies:
+      '@intlify/core-base': 10.0.5
+      '@intlify/shared': 10.0.5
+      '@vue/devtools-api': 6.6.4
+      vue: 3.5.13(typescript@5.7.2)
+
+  vue-router@4.5.0(vue@3.5.13(typescript@5.7.2)):
     dependencies:
       '@vue/devtools-api': 6.6.4
-      vue: 3.4.38(typescript@5.7.2)
+      vue: 3.5.13(typescript@5.7.2)
 
   vue-sonner@1.3.0: {}
 
@@ -13913,19 +14173,9 @@ snapshots:
 
   vue3-simple-icons@13.2.0(typescript@5.7.2):
     dependencies:
-      vue: 3.4.38(typescript@5.7.2)
+      vue: 3.5.13(typescript@5.7.2)
     transitivePeerDependencies:
       - typescript
-
-  vue@3.4.38(typescript@5.7.2):
-    dependencies:
-      '@vue/compiler-dom': 3.4.38
-      '@vue/compiler-sfc': 3.4.38
-      '@vue/runtime-dom': 3.4.38
-      '@vue/server-renderer': 3.4.38(vue@3.4.38(typescript@5.7.2))
-      '@vue/shared': 3.4.38
-    optionalDependencies:
-      typescript: 5.7.2
 
   vue@3.5.13(typescript@5.7.2):
     dependencies:


### PR DESCRIPTION
Implemented multi-language support for the application:
- Added @nuxtjs/i18n plugin configuration
- Created locale files for English (en-US) and Chinese (zh-CN)
- Updated components to use translation keys
- Added language switcher in header
- Configured VSCode i18n-ally settings
- Prepared translation infrastructure for future language expansions