### PR TITLE
When deploying with Cloudflare workers, sometimes the real IP address cannot be obtained

### DIFF
--- a/server/utils/access-log.ts
+++ b/server/utils/access-log.ts
@@ -60,7 +60,7 @@ function blobs2logs(blobs: string[]) {
 }
 
 export function useAccessLog(event: H3Event) {
-  const ip = getHeader(event, 'x-real-ip') || getRequestIP(event, { xForwardedFor: true })
+  const ip = getHeader(event, 'cf-connecting-ip') || getHeader(event, 'x-real-ip') || getRequestIP(event, { xForwardedFor: true })
 
   const { host: referer } = parseURL(getHeader(event, 'referer'))
 


### PR DESCRIPTION
In some cases, the real IP address may not be correctly identified

By querying the raw data recorded by the cloudflare analytics engine, the output is as follows:

Query
`SELECT 
    FormatDateTime(timestamp, '%Y-%m-%d %H:%M:%S', 'Etc/UTC') AS time,  blob3 AS UA, blob4 AS IP
FROM 
    sink 
WHERE 
    timestamp >= toDateTime('2025-04-15 00:00:00')
ORDER BY time
FORMAT JSON`

Output
`
{
    "time": "2025-04-15 00:00:25",
    "UA": "Mozilla/5.0 (Linux; U; Android 10; in-id; CPH2179 Build/QP1A.190711.020) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.88 Mobile Safari/537.36 HeyTapBrowser/45.12.2.1",
    "IP": "unix:"
}
`

