### PR TITLE
Fix: Prevent date fields from wrapping on the dashboard card

### DIFF
--- a/components/dashboard/links/Link.vue
+++ b/components/dashboard/links/Link.vue
@@ -165,7 +165,7 @@ function copyLink() {
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger as-child>
-              <span class="inline-flex items-center leading-5"><CalendarPlus2 class="w-4 h-4 mr-1" /> {{ shortDate(link.createdAt) }}</span>
+              <span class="inline-flex items-center leading-5 whitespace-nowrap"><CalendarPlus2 class="w-4 h-4 mr-1" /> {{ shortDate(link.createdAt) }}</span>
             </TooltipTrigger>
             <TooltipContent>
               <p>Created At: {{ longDate(link.createdAt) }}</p>
@@ -178,7 +178,7 @@ function copyLink() {
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger as-child>
-                <span class="inline-flex items-center leading-5"><Hourglass class="w-4 h-4 mr-1" /> {{ shortDate(link.expiration) }}</span>
+                <span class="inline-flex items-center leading-5 whitespace-nowrap"><Hourglass class="w-4 h-4 mr-1" /> {{ shortDate(link.expiration) }}</span>
               </TooltipTrigger>
               <TooltipContent>
                 <p>Expires At: {{ longDate(link.expiration) }}</p>


### PR DESCRIPTION
This small patch fixes an issue where long URLs would push the “Created” and “Expires” dates onto multiple lines in the dashboard link card. By adding a simple `whitespace-nowrap` style to the date container, both dates now stay on a single line, regardless of link length.

Before (dates wrapped):
<img width="473" alt="SCR-20250403-mojb" src="https://github.com/user-attachments/assets/1ff90239-c62e-47b7-8d84-0f05cdb0470d" />


After (dates on one line):
<img width="473" alt="SCR-20250403-morp" src="https://github.com/user-attachments/assets/26be15c1-3c77-42f6-a390-83ec8cb08bb1" />

Please review!