### PR TITLE
Update default sorting order to 'newest' in links component

### DIFF
--- a/app/components/dashboard/links/Index.vue
+++ b/app/components/dashboard/links/Index.vue
@@ -8,7 +8,7 @@ let cursor = ''
 let listComplete = false
 let listError = false
 
-const sortBy = ref('az')
+const sortBy = ref('newest')
 
 const displayedLinks = computed(() => {
   const sorted = [...links.value]

--- a/app/components/dashboard/links/Sort.vue
+++ b/app/components/dashboard/links/Sort.vue
@@ -4,7 +4,7 @@ import { ArrowUpDown } from 'lucide-vue-next'
 defineProps({
   sortBy: {
     type: String,
-    default: 'az',
+    default: 'newest',
   },
 })
 


### PR DESCRIPTION
# Change default link sorting to "newest first"

## Summary
This PR changes the default sorting of links from alphabetical (A-Z) to newest first. This improves the user experience by showing the most recently created links at the top of the list.

## Why this change is beneficial
- **Improved Accessibility**: Users can immediately see their most recent links without having to change the sort order
- **Better UX Flow**: After creating a new link, users naturally expect to see it at the top of the list
- **Common Pattern**: Most modern applications (like Gmail, Twitter, etc.) default to showing newest content first
- **Consistent Behavior**: This aligns with the existing behavior where new links are already being unshifted to the top of the list when created

## Changes
- Updated the default `sortBy` value in `app/components/dashboard/links/Index.vue` from 'az' to 'newest'

## Testing
- Verified that links are sorted by creation date (newest first) when the page loads
- Confirmed that the sort dropdown still works correctly for all sorting options
- Tested that new link creation still maintains the proper order

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the default sorting order for links to display the newest items first instead of sorting alphabetically.
  * Changed the initial sorting criterion in the sorting options to prioritize newest links by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->