### PR TITLE
chore: use env variable for site token fallback to generated UUID

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -20,7 +20,7 @@ export default defineNuxtConfig({
   },
 
   runtimeConfig: {
-    siteToken: crypto.randomUUID(),
+    siteToken: process.env.NUXT_SITE_TOKEN || crypto.randomUUID(),
     redirectStatusCode: '301',
     linkCacheTtl: 60,
     redirectWithQuery: false,


### PR DESCRIPTION
Cloudflare/Nuxt aren't successfully combining the `runtimeConfig` as expected. This fixes it.

Resolves this issue: https://github.com/ccbikai/Sink/issues/190