### PR TITLE
Update name in Wrangler configuration file to match deployed Worker

### DIFF
--- a/app/components/dashboard/links/Search.vue
+++ b/app/components/dashboard/links/Search.vue
@@ -62,7 +62,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <TriggerTemplate v-slot="attrs">
+  <TriggerTemplate v-slot="{ $slots: _, ...attrs }">
     <Button
       v-bind="attrs"
       variant="outline"


### PR DESCRIPTION
The Worker name in your Wrangler configuration file does not match the name of the deployed Worker in the Cloudflare Dashboard.
		Cloudflare automatically generated this PR to resolve the mismatch and avoid inconsistencies between environments. For more information, see: https://developers.cloudflare.com/workers/ci-cd/builds/troubleshoot/#workers-name-requirement