### PR TITLE
Update clientTimezone regex and add tests for endpoints (Fixed #277)

### DIFF
--- a/server/api/stats/heatmap.get.ts
+++ b/server/api/stats/heatmap.get.ts
@@ -6,7 +6,7 @@ const { select } = SqlBricks
 
 const HeatmapQuerySchema = QuerySchema.extend({
   clientTimezone: z.string()
-    .regex(/^[A-Z_]+(?:\/[A-Z_-]+)*$/i)
+    .regex(/^[\w+-]+(?:\/[\w+-]+)*$/)
     .max(64)
     .default('Etc/UTC'),
 })

--- a/server/api/stats/views.get.ts
+++ b/server/api/stats/views.get.ts
@@ -13,7 +13,7 @@ const unitMap: { [x: string]: string } = {
 const ViewsQuerySchema = QuerySchema.extend({
   unit: z.enum(['minute', 'hour', 'day']),
   clientTimezone: z.string()
-    .regex(/^[A-Z_]+(?:\/[A-Z_-]+)*$/i)
+    .regex(/^[\w+-]+(?:\/[\w+-]+)*$/)
     .max(64)
     .default('Etc/UTC'),
 })

--- a/tests/api/stats.spec.ts
+++ b/tests/api/stats.spec.ts
@@ -100,6 +100,12 @@ describe('/api/stats/views', () => {
     expect(response.status).toBe(200)
   })
 
+  it('supports offset-style clientTimezone values', async () => {
+    const response = await fetchWithAuth('/api/stats/views?slug=0&unit=day&clientTimezone=Etc/GMT-8')
+
+    expect(response.status).toBe(200)
+  })
+
   it('returns 400 for invalid clientTimezone format', async () => {
     const response = await fetchWithAuth('/api/stats/views?slug=0&unit=day&clientTimezone=invalid<>timezone')
 
@@ -120,6 +126,32 @@ describe('/api/stats/views', () => {
 
   it('returns 401 when accessing without auth', async () => {
     const response = await fetch('/api/stats/views?slug=0&unit=day')
+
+    expect(response.status).toBe(401)
+  })
+})
+
+describe('/api/stats/heatmap', () => {
+  it('supports clientTimezone parameter', async () => {
+    const response = await fetchWithAuth('/api/stats/heatmap?clientTimezone=Asia/Shanghai')
+
+    expect(response.status).toBe(200)
+  })
+
+  it('supports offset-style clientTimezone values', async () => {
+    const response = await fetchWithAuth('/api/stats/heatmap?clientTimezone=Etc/GMT-8')
+
+    expect(response.status).toBe(200)
+  })
+
+  it('returns 400 for invalid clientTimezone format', async () => {
+    const response = await fetchWithAuth('/api/stats/heatmap?clientTimezone=invalid<>timezone')
+
+    expect(response.status).toBe(400)
+  })
+
+  it('returns 401 when accessing without auth', async () => {
+    const response = await fetch('/api/stats/heatmap?clientTimezone=Asia/Shanghai')
 
     expect(response.status).toBe(401)
   })


### PR DESCRIPTION

Fixed #277 

This pull request updates the validation rules for the `clientTimezone` parameter in both the stats views and heatmap APIs to allow a wider range of valid timezone formats, including offset-style values (like `Etc/GMT-8`). It also adds comprehensive tests to ensure the new formats are accepted and invalid ones are properly rejected.

**Validation improvements:**

* Updated the regular expression in both `ViewsQuerySchema` (`server/api/stats/views.get.ts`) and `HeatmapQuerySchema` (`server/api/stats/heatmap.get.ts`) to allow offset-style timezone values (e.g., `Etc/GMT-8`) and a broader set of valid characters. [[1]](diffhunk://#diff-6d715dec1e6c76c001411beb4430744fbaa964feb9745b1c41fc3e8609cb2de2L16-R16) [[2]](diffhunk://#diff-52da285b9190a02c3913ae1d6376892c5d862ef4831400e644f29578ceeef3bdL9-R9)

**Testing enhancements:**

* Added tests for `/api/stats/views` and `/api/stats/heatmap` endpoints to verify support for offset-style `clientTimezone` values, proper handling of invalid formats, and authentication requirements. [[1]](diffhunk://#diff-7cc4ac381484d4b45e27767f21bc21fe74e6c08033f0943b35da4a2a53c37361R103-R108) [[2]](diffhunk://#diff-7cc4ac381484d4b45e27767f21bc21fe74e6c08033f0943b35da4a2a53c37361R133-R158)