### PR TITLE
feat: proxy cloaked links through same-origin route

### DIFF
--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -10,5 +10,6 @@ export default defineAppConfig({
   slugRegex: /^[a-z0-9]+(?:-[a-z0-9]+)*$/i,
   reserveSlug: [
     'dashboard',
+    '_cloak',
   ],
 })

--- a/server/middleware/1.redirect.ts
+++ b/server/middleware/1.redirect.ts
@@ -154,7 +154,7 @@ export default eventHandler(async (event) => {
 
       if (link.cloaking) {
         const baseUrl = `${getRequestProtocol(event)}://${getRequestHost(event)}`
-        const html = generateCloakingHtml(link, buildTarget(link.url), baseUrl)
+        const html = generateCloakingHtml(link, baseUrl)
         setHeader(event, 'Content-Type', 'text/html; charset=utf-8')
         setHeader(event, 'Cache-Control', 'no-store, private')
         return html

--- a/server/routes/_cloak/[slug].get.ts
+++ b/server/routes/_cloak/[slug].get.ts
@@ -1,0 +1,3 @@
+export default eventHandler(async (event) => {
+  return handleCloakProxy(event)
+})

--- a/server/routes/_cloak/[slug]/[...path].get.ts
+++ b/server/routes/_cloak/[slug]/[...path].get.ts
@@ -1,0 +1,3 @@
+export default eventHandler(async (event) => {
+  return handleCloakProxy(event, getRouterParam(event, 'path'))
+})

--- a/server/utils/cloak-proxy.ts
+++ b/server/utils/cloak-proxy.ts
@@ -1,0 +1,112 @@
+import type { H3Event } from 'h3'
+import { LinkSchema } from '#shared/schemas/link'
+import { withQuery } from 'ufo'
+
+const slugValidator = LinkSchema.shape.slug
+const BLOCKED_RESPONSE_HEADERS = [
+  'content-encoding',
+  'content-length',
+  'content-security-policy',
+  'content-security-policy-report-only',
+  'x-frame-options',
+]
+
+function cleanProxyHeaders(headers: Headers): Headers {
+  const cleaned = new Headers(headers)
+  for (const header of BLOCKED_RESPONSE_HEADERS) {
+    cleaned.delete(header)
+  }
+  return cleaned
+}
+
+function rewriteAssetUrl(value: string, targetUrl: string, proxyBase: string): string {
+  const trimmed = value.trim()
+  if (!trimmed || trimmed.startsWith('#'))
+    return value
+
+  try {
+    const parsed = new URL(trimmed, targetUrl)
+    const target = new URL(targetUrl)
+    if (!['http:', 'https:'].includes(parsed.protocol) || parsed.origin !== target.origin)
+      return value
+
+    return `${proxyBase}${parsed.pathname}${parsed.search}${parsed.hash}`
+  }
+  catch {
+    return value
+  }
+}
+
+export function rewriteCloakedHtml(html: string, targetUrl: string, proxyBase: string): string {
+  return html.replace(
+    /\b(src|href|poster)=("([^"]*)"|'([^']*)')/gi,
+    (match, attribute: string, quoted: string, doubleQuoted?: string, singleQuoted?: string) => {
+      const value = doubleQuoted ?? singleQuoted ?? ''
+      const quote = quoted.startsWith('"') ? '"' : '\''
+      const rewritten = rewriteAssetUrl(value, targetUrl, proxyBase)
+      return `${attribute}=${quote}${rewritten}${quote}`
+    },
+  )
+}
+
+function resolveProxyTarget(linkUrl: string, proxiedPath?: string): string {
+  if (!proxiedPath)
+    return linkUrl
+
+  const target = new URL(linkUrl)
+  target.pathname = `/${proxiedPath}`
+  target.search = ''
+  target.hash = ''
+  return target.toString()
+}
+
+export async function handleCloakProxy(event: H3Event, proxiedPath?: string): Promise<Response> {
+  const slug = getRouterParam(event, 'slug')
+  const slugResult = slugValidator.safeParse(slug)
+  if (!slug || !slugResult.success) {
+    throw createError({ status: 400, statusText: 'Invalid slug format' })
+  }
+
+  const { linkCacheTtl, caseSensitive } = useRuntimeConfig(event)
+  const lookupSlug = caseSensitive ? slug : slug.toLowerCase()
+  let link = await getLink(event, lookupSlug, linkCacheTtl)
+  if (!caseSensitive && !link && lookupSlug !== slug) {
+    link = await getLink(event, slug, linkCacheTtl)
+  }
+  if (!link) {
+    throw createError({ status: 404, statusText: 'Link not found' })
+  }
+  if (!link.cloaking) {
+    throw createError({ status: 404, statusText: 'Link not found' })
+  }
+
+  const targetUrl = withQuery(resolveProxyTarget(link.url, proxiedPath), getQuery(event))
+  const response = await fetch(targetUrl, {
+    headers: {
+      'User-Agent': getHeader(event, 'user-agent') || 'Sink Cloak Proxy',
+      'Accept': getHeader(event, 'accept') || '*/*',
+    },
+    redirect: 'follow',
+  })
+  const headers = cleanProxyHeaders(response.headers)
+  const contentType = headers.get('content-type') || ''
+
+  if (contentType.includes('text/html')) {
+    const html = await response.text()
+    const proxyBase = `/_cloak/${encodeURIComponent(slug)}`
+    const rewritten = rewriteCloakedHtml(html, targetUrl, proxyBase)
+    headers.set('content-type', 'text/html; charset=utf-8')
+    headers.set('cache-control', 'no-store, private')
+    return new Response(rewritten, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    })
+  }
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  })
+}

--- a/server/utils/template.ts
+++ b/server/utils/template.ts
@@ -27,8 +27,9 @@ function buildMetaTags(link: Link, baseUrl: string) {
   return { title, tags }
 }
 
-export function generateCloakingHtml(link: Link, targetUrl: string, baseUrl: string): string {
+export function generateCloakingHtml(link: Link, baseUrl: string): string {
   const { title, tags } = buildMetaTags(link, baseUrl)
+  const cloakUrl = `/_cloak/${encodeURIComponent(link.slug)}`
 
   return `<!DOCTYPE html>
 <html>
@@ -38,8 +39,8 @@ export function generateCloakingHtml(link: Link, targetUrl: string, baseUrl: str
     ${tags}
 </head>
 <body style="margin:0;overflow:hidden">
-    <iframe src="${escape(targetUrl)}" style="width:100vw;height:100vh;border:none" sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox" allowfullscreen referrerpolicy="no-referrer"></iframe>
-    <noscript><meta http-equiv="refresh" content="0;url=${escape(targetUrl)}"></noscript>
+    <iframe src="${escape(cloakUrl)}" style="width:100vw;height:100vh;border:none" sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox" allowfullscreen referrerpolicy="no-referrer"></iframe>
+    <noscript><p>JavaScript is required to view this page.</p></noscript>
 </body>
 </html>`
 }

--- a/tests/api/cloak.spec.ts
+++ b/tests/api/cloak.spec.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { fetch, postJson } from '../utils'
+
+describe.sequential('proxy link cloaking', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('renders cloaking iframe without leaking the target url', async () => {
+    const payload = {
+      url: 'https://target.example/',
+      slug: 'cloak-source-test',
+      cloaking: true,
+      title: 'Cloaked page',
+    }
+    const createResponse = await postJson('/api/link/create', payload)
+    expect(createResponse.status).toBe(201)
+
+    const response = await fetch(`/${payload.slug}`)
+    expect(response.status).toBe(200)
+
+    const html = await response.text()
+    expect(html).toContain(`src="/_cloak/${payload.slug}"`)
+    expect(html).not.toContain(payload.url)
+  })
+
+  it('proxies cloaked html and rewrites common same-origin asset urls', async () => {
+    const payload = {
+      url: 'https://spa.example/',
+      slug: 'cloak-proxy-test',
+      cloaking: true,
+    }
+    const createResponse = await postJson('/api/link/create', payload)
+    expect(createResponse.status).toBe(201)
+
+    const fetchMock = vi.fn(async () => new Response(`<!DOCTYPE html>
+<html>
+<head>
+  <script src="/assets/app.js"></script>
+  <link href="assets/app.css" rel="stylesheet">
+</head>
+<body>
+  <img src="./logo.png">
+  <img src="https://cdn.example/logo.png">
+</body>
+</html>`, {
+      headers: {
+        'content-type': 'text/html',
+        'content-security-policy': 'frame-ancestors none',
+        'x-frame-options': 'DENY',
+      },
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const response = await fetch(`/_cloak/${payload.slug}`)
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-security-policy')).toBeNull()
+    expect(response.headers.get('x-frame-options')).toBeNull()
+
+    const html = await response.text()
+    expect(fetchMock).toHaveBeenCalledWith('https://spa.example/', expect.any(Object))
+    expect(html).toContain(`src="/_cloak/${payload.slug}/assets/app.js"`)
+    expect(html).toContain(`href="/_cloak/${payload.slug}/assets/app.css"`)
+    expect(html).toContain(`src="/_cloak/${payload.slug}/logo.png"`)
+    expect(html).toContain('src="https://cdn.example/logo.png"')
+  })
+
+  it('proxies cloaked static assets by path', async () => {
+    const payload = {
+      url: 'https://spa-static.example/',
+      slug: 'cloak-asset-test',
+      cloaking: true,
+    }
+    const createResponse = await postJson('/api/link/create', payload)
+    expect(createResponse.status).toBe(201)
+
+    const fetchMock = vi.fn(async () => new Response('console.log("ok")', {
+      headers: { 'content-type': 'application/javascript' },
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const response = await fetch(`/_cloak/${payload.slug}/assets/app.js`)
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe('console.log("ok")')
+    expect(fetchMock).toHaveBeenCalledWith('https://spa-static.example/assets/app.js', expect.any(Object))
+  })
+
+  it('does not proxy non-cloaked links', async () => {
+    const payload = {
+      url: 'https://plain.example/',
+      slug: 'cloak-reserved-test',
+    }
+    const createResponse = await postJson('/api/link/create', payload)
+    expect(createResponse.status).toBe(201)
+
+    const response = await fetch(`/_cloak/${payload.slug}`)
+    expect(response.status).toBe(404)
+  })
+})


### PR DESCRIPTION
## Summary

This PR updates Link Cloaking to load the destination page through a same-origin proxy route instead of embedding the destination URL directly in the cloaking HTML.

When cloaking is enabled, the outer page now renders an iframe pointing to `/_cloak/{slug}`. The proxy route fetches the configured destination URL server-side and returns the destination HTML/assets through the short-link domain.

## Why

Currently, Link Cloaking keeps the short link in the browser address bar by loading the destination URL in a full-screen iframe.

However, the generated page source still contains the original destination URL in the iframe `src` and the `<noscript>` fallback. This means users can reveal the destination URL by viewing the page source, even when cloaking is enabled.

This PR avoids exposing the destination URL directly in the initial cloaking page source.

## Changes

- Change cloaked iframe `src` from the destination URL to `/_cloak/{slug}`.
- Add same-origin proxy routes for cloaked pages:
  - `/_cloak/{slug}`
  - `/_cloak/{slug}/...`
- Proxy the destination HTML through the server.
- Rewrite common same-origin asset references in HTML:
  - `src`
  - `href`
  - `poster`
- Strip frame-blocking response headers from proxied responses:
  - `content-security-policy`
  - `content-security-policy-report-only`
  - `x-frame-options`
- Reserve `_cloak` to avoid conflicts with short-link slugs.
- Add tests for the cloaking HTML, proxy behavior, asset rewriting, and non-cloaked links.

## Scope and Limitations

This is intended as a lightweight proxy for cloaked links, especially simple SPA/static-asset use cases.

It is not a full reverse proxy and does not guarantee that the destination can never be inferred. It also does not attempt to rewrite JavaScript, CSS `url(...)`, API calls, WebSocket connections, or complex in-page navigation.

The goal is specifically to avoid exposing the destination URL directly in the initial cloaking HTML.

## Validation

- `npx --yes pnpm@10.28.2 types:check`
- `npx --yes pnpm@10.28.2 exec eslint app/app.config.ts server/middleware/1.redirect.ts server/utils/template.ts server/utils/cloak-proxy.ts tests/api/cloak.spec.ts`
- `$env:NODE_OPTIONS='--max-old-space-size=8192'; npx --yes pnpm@10.28.2 exec nuxt build`