### PR TITLE
fix: prevent browsers from caching link redirects

### DIFF
--- a/server/middleware/1.redirect.ts
+++ b/server/middleware/1.redirect.ts
@@ -152,6 +152,8 @@ export default eventHandler(async (event) => {
       }
 
       if (deviceRedirectUrl) {
+        // Never let browsers/CDNs cache the redirect: links can be edited or deleted.
+        setHeader(event, 'Cache-Control', 'no-store')
         return sendRedirect(event, finalTargetUrl, +redirectStatusCode)
       }
 
@@ -170,6 +172,8 @@ export default eventHandler(async (event) => {
         return html
       }
 
+      // Never let browsers/CDNs cache the redirect: links can be edited or deleted.
+      setHeader(event, 'Cache-Control', 'no-store')
       return sendRedirect(event, finalTargetUrl, +redirectStatusCode)
     }
     else {


### PR DESCRIPTION
## Problem

Link redirects are issued with `sendRedirect(event, finalTargetUrl, +redirectStatusCode)` and **no `Cache-Control` header**. Since `redirectStatusCode` defaults to `301`, browsers cache the redirect persistently.

The practical consequence: after you **edit or delete** a link in the dashboard, the server correctly returns the new target / a 404 (verified with `curl`), but any browser that already visited the old short link keeps redirecting to the **stale target from its local 301 cache** — the request never reaches the worker again. For a shortener whose links are mutable by design, this looks like "deleted links still work."

## Fix

Set `Cache-Control: no-store` on both redirect paths (the device-specific redirect and the default redirect), so every visit re-hits the worker and reflects the current link state.

This mirrors the `no-store` already applied to the password / unsafe-warning / cloaking HTML responses in the same middleware. It is a minimal, behavior-preserving change — the redirect status code is left untouched (still configurable via `NUXT_REDIRECT_STATUS_CODE`); `no-store` simply stops clients from caching the hop.

## Testing

- Before: `curl -I /<slug>` → `301` with no `Cache-Control`; deleting the link still resolves in a browser that visited it earlier.
- After: `curl -I /<slug>` → `301` + `cache-control: no-store`; edits/deletes take effect immediately on next visit.

```
server/middleware/1.redirect.ts | 4 ++++
1 file changed, 4 insertions(+)
```