### PR TITLE
fix(api): support server-side sorting for newest, oldest, and Z-A pagination in link listing

### DIFF
--- a/layers/dashboard/app/components/dashboard/links/Index.vue
+++ b/layers/dashboard/app/components/dashboard/links/Index.vue
@@ -52,12 +52,10 @@ onMounted(() => {
 })
 
 const displayedLinks = computed(() => {
+  if (linksStore.sortBy === 'newest' || linksStore.sortBy === 'oldest')
+    return links.value
   const sorted = [...links.value]
   switch (linksStore.sortBy) {
-    case 'newest':
-      return sorted.sort((a, b) => b.createdAt - a.createdAt)
-    case 'oldest':
-      return sorted.sort((a, b) => a.createdAt - b.createdAt)
     case 'az':
       return sorted.sort((a, b) => a.slug.localeCompare(b.slug))
     case 'za':
@@ -67,12 +65,22 @@ const displayedLinks = computed(() => {
   }
 })
 
+function sortParam() {
+  switch (linksStore.sortBy) {
+    case 'newest': return 'createdAt_desc'
+    case 'oldest': return 'createdAt_asc'
+    case 'za': return 'slug_desc'
+    default: return 'slug_asc'
+  }
+}
+
 async function getLinks() {
   try {
     const data = await useAPI<LinkListResponse>('/api/link/list', {
       query: {
         limit,
         cursor,
+        sort: sortParam(),
       },
     })
     const newLinks = data.links.filter(Boolean)
@@ -89,6 +97,14 @@ async function getLinks() {
     listError.value = true
   }
 }
+
+watch(() => linksStore.sortBy, () => {
+  links.value = []
+  cursor = ''
+  listComplete.value = false
+  listError.value = false
+  getLinks()
+})
 
 const { isLoading } = useInfiniteScroll(
   scrollContainer as unknown as Ref<HTMLElement | null>,

--- a/server/api/link/list.get.ts
+++ b/server/api/link/list.get.ts
@@ -41,15 +41,15 @@ export default eventHandler(async (event) => {
   const { limit, cursor, sort } = await getValidatedQuery(event, ListQuerySchema.parse)
 
   let list: ListLinksResult
-  if (sort === 'createdAt_desc' || sort === 'createdAt_asc') {
+  if (sort === 'slug_asc') {
+    list = await listLinks(event, { limit, cursor })
+  }
+  else {
     list = await listLinksSorted(event, {
       limit,
       cursor,
-      direction: sort === 'createdAt_desc' ? 'newest' : 'oldest',
+      sort,
     })
-  }
-  else {
-    list = await listLinks(event, { limit, cursor })
   }
 
   return {

--- a/server/api/link/list.get.ts
+++ b/server/api/link/list.get.ts
@@ -1,3 +1,4 @@
+import type { ListLinksResult } from '#server/utils/link-store'
 import { z } from 'zod'
 
 defineRouteMeta({
@@ -19,6 +20,13 @@ defineRouteMeta({
         schema: { type: 'string' },
         description: 'Pagination cursor from previous response',
       },
+      {
+        name: 'sort',
+        in: 'query',
+        required: false,
+        schema: { type: 'string', enum: ['slug_asc', 'slug_desc', 'createdAt_desc', 'createdAt_asc'], default: 'slug_asc' },
+        description: 'Sort order for links',
+      },
     ],
   },
 })
@@ -26,12 +34,24 @@ defineRouteMeta({
 const ListQuerySchema = z.object({
   limit: z.coerce.number().max(1024).default(20),
   cursor: z.string().trim().max(1024).optional(),
+  sort: z.enum(['slug_asc', 'slug_desc', 'createdAt_desc', 'createdAt_asc']).default('slug_asc'),
 })
 
 export default eventHandler(async (event) => {
-  const { limit, cursor } = await getValidatedQuery(event, ListQuerySchema.parse)
+  const { limit, cursor, sort } = await getValidatedQuery(event, ListQuerySchema.parse)
 
-  const list = await listLinks(event, { limit, cursor })
+  let list: ListLinksResult
+  if (sort === 'createdAt_desc' || sort === 'createdAt_asc') {
+    list = await listLinksSorted(event, {
+      limit,
+      cursor,
+      direction: sort === 'createdAt_desc' ? 'newest' : 'oldest',
+    })
+  }
+  else {
+    list = await listLinks(event, { limit, cursor })
+  }
+
   return {
     ...list,
     links: sanitizeLinksPassword(list.links),

--- a/server/utils/link-store.ts
+++ b/server/utils/link-store.ts
@@ -63,10 +63,68 @@ interface ListLinksOptions {
   cursor?: string
 }
 
-interface ListLinksResult {
+export interface ListLinksResult {
   links: (Link | null)[]
   list_complete: boolean
   cursor?: string
+}
+
+export async function listLinksSorted(event: H3Event, options: ListLinksOptions & { direction: 'newest' | 'oldest' }): Promise<ListLinksResult> {
+  const { cloudflare } = event.context
+  const { KV } = cloudflare.env
+
+  let cursorCreatedAt = 0
+  let cursorSlug = ''
+  if (options.cursor) {
+    const sep = options.cursor.indexOf('::')
+    if (sep !== -1) {
+      cursorCreatedAt = Number(options.cursor.slice(0, sep))
+      cursorSlug = options.cursor.slice(sep + 2)
+    }
+  }
+
+  const allKeys: string[] = []
+  let kvCursor: string | undefined
+  let listComplete = false
+  while (!listComplete) {
+    const result = await KV.list({ prefix: 'link:', limit: 1000, cursor: kvCursor })
+    allKeys.push(...result.keys.map(k => k.name))
+    listComplete = result.list_complete
+    if (!listComplete && 'cursor' in result)
+      kvCursor = result.cursor
+  }
+
+  const allLinks: Link[] = (
+    await Promise.all(allKeys.map(key => KV.get(key, { type: 'json' }) as Promise<Link | null>))
+  ).filter((l): l is Link => l !== null)
+
+  if (options.direction === 'newest') {
+    allLinks.sort((a, b) => b.createdAt - a.createdAt || a.slug.localeCompare(b.slug))
+  }
+  else {
+    allLinks.sort((a, b) => a.createdAt - b.createdAt || a.slug.localeCompare(b.slug))
+  }
+
+  let startIndex = 0
+  if (options.cursor) {
+    startIndex = allLinks.findIndex(l =>
+      options.direction === 'newest'
+        ? l.createdAt < cursorCreatedAt || (l.createdAt === cursorCreatedAt && l.slug > cursorSlug)
+        : l.createdAt > cursorCreatedAt || (l.createdAt === cursorCreatedAt && l.slug > cursorSlug),
+    )
+    if (startIndex === -1)
+      return { links: [], list_complete: true }
+  }
+
+  const page = allLinks.slice(startIndex, startIndex + options.limit)
+  const lastItem = page[page.length - 1]
+  const nextCursor = lastItem ? `${lastItem.createdAt}::${lastItem.slug}` : ''
+
+  return {
+    links: page,
+    list_complete: startIndex + options.limit >= allLinks.length,
+    cursor: nextCursor,
+  }
 }
 
 export async function listLinks(event: H3Event, options: ListLinksOptions): Promise<ListLinksResult> {

--- a/server/utils/link-store.ts
+++ b/server/utils/link-store.ts
@@ -69,19 +69,12 @@ export interface ListLinksResult {
   cursor?: string
 }
 
-export async function listLinksSorted(event: H3Event, options: ListLinksOptions & { direction: 'newest' | 'oldest' }): Promise<ListLinksResult> {
+export async function listLinksSorted(
+  event: H3Event,
+  options: ListLinksOptions & { sort: 'createdAt_desc' | 'createdAt_asc' | 'slug_desc' },
+): Promise<ListLinksResult> {
   const { cloudflare } = event.context
   const { KV } = cloudflare.env
-
-  let cursorCreatedAt = 0
-  let cursorSlug = ''
-  if (options.cursor) {
-    const sep = options.cursor.indexOf('::')
-    if (sep !== -1) {
-      cursorCreatedAt = Number(options.cursor.slice(0, sep))
-      cursorSlug = options.cursor.slice(sep + 2)
-    }
-  }
 
   const allKeys: string[] = []
   let kvCursor: string | undefined
@@ -98,27 +91,63 @@ export async function listLinksSorted(event: H3Event, options: ListLinksOptions 
     await Promise.all(allKeys.map(key => KV.get(key, { type: 'json' }) as Promise<Link | null>))
   ).filter((l): l is Link => l !== null)
 
-  if (options.direction === 'newest') {
+  if (options.sort === 'createdAt_desc') {
     allLinks.sort((a, b) => b.createdAt - a.createdAt || a.slug.localeCompare(b.slug))
   }
-  else {
+  else if (options.sort === 'createdAt_asc') {
     allLinks.sort((a, b) => a.createdAt - b.createdAt || a.slug.localeCompare(b.slug))
+  }
+  else if (options.sort === 'slug_desc') {
+    allLinks.sort((a, b) => b.slug.localeCompare(a.slug))
   }
 
   let startIndex = 0
   if (options.cursor) {
-    startIndex = allLinks.findIndex(l =>
-      options.direction === 'newest'
-        ? l.createdAt < cursorCreatedAt || (l.createdAt === cursorCreatedAt && l.slug > cursorSlug)
-        : l.createdAt > cursorCreatedAt || (l.createdAt === cursorCreatedAt && l.slug > cursorSlug),
-    )
+    if (options.sort === 'createdAt_desc') {
+      let cursorCreatedAt = 0
+      let cursorSlug = ''
+      const sep = options.cursor.indexOf('::')
+      if (sep !== -1) {
+        cursorCreatedAt = Number(options.cursor.slice(0, sep))
+        cursorSlug = options.cursor.slice(sep + 2)
+      }
+      startIndex = allLinks.findIndex(l =>
+        l.createdAt < cursorCreatedAt || (l.createdAt === cursorCreatedAt && l.slug > cursorSlug),
+      )
+    }
+    else if (options.sort === 'createdAt_asc') {
+      let cursorCreatedAt = 0
+      let cursorSlug = ''
+      const sep = options.cursor.indexOf('::')
+      if (sep !== -1) {
+        cursorCreatedAt = Number(options.cursor.slice(0, sep))
+        cursorSlug = options.cursor.slice(sep + 2)
+      }
+      startIndex = allLinks.findIndex(l =>
+        l.createdAt > cursorCreatedAt || (l.createdAt === cursorCreatedAt && l.slug > cursorSlug),
+      )
+    }
+    else if (options.sort === 'slug_desc') {
+      const cursorSlug = options.cursor
+      startIndex = allLinks.findIndex(l => l.slug < cursorSlug)
+    }
+
     if (startIndex === -1)
       return { links: [], list_complete: true }
   }
 
   const page = allLinks.slice(startIndex, startIndex + options.limit)
   const lastItem = page[page.length - 1]
-  const nextCursor = lastItem ? `${lastItem.createdAt}::${lastItem.slug}` : ''
+
+  let nextCursor = ''
+  if (lastItem) {
+    if (options.sort === 'slug_desc') {
+      nextCursor = lastItem.slug
+    }
+    else {
+      nextCursor = `${lastItem.createdAt}::${lastItem.slug}`
+    }
+  }
 
   return {
     links: page,


### PR DESCRIPTION
## Problem

`KV.list()` returns pages in alphabetical key order, but the dashboard's sorting for "newest", "oldest", and "Z-A" (za) was done client-side on already-loaded data only. This means:

1. **Wrong page priority** — for newest, oldest, and Z-A sorting, the first page always contains alphabetically early slugs (A-Z), not the actual sorted entries. Users must scroll through all pages before seeing the correct top links.
2. **Cursor skips entries** — `KV.list()` cursor represents an alphabetical position. Any link created/sorted that falls before the cursor is **never returned** in subsequent pages during pagination.

## Solution

Add a `sort` query parameter to `GET /api/link/list` supporting `slug_asc` (default), `slug_desc` (Z-A), `createdAt_desc` (newest), and `createdAt_asc` (oldest).

- For `slug_asc` (A-Z), the server continues to use native `KV.list()` for optimal performance.
- For `slug_desc`, `createdAt_desc`, and `createdAt_asc`, the server:
  1. Lists all KV keys (loops through `KV.list()` pages of 1000)
  2. Fetches all links
  3. Sorts by the requested criteria
  4. Returns the requested page with a custom cursor:
     - `{createdAt}::{slug}` for creation date sorting
     - `{slug}` for Z-A (`slug_desc`) sorting

The client-side sort for `newest`/`oldest` is removed, and all custom sorting relies on the server-side pagination.

## Changes

- `server/utils/link-store.ts` — add `listLinksSorted()` supporting custom sorting criteria
- `server/api/link/list.get.ts` — add `sort` query param and route to `listLinksSorted()` or `listLinks()`
- `layers/dashboard/app/components/dashboard/links/Index.vue` — pass sort, reset list on sort change