### PR TITLE
feat: record and display who created and edited each link

### DIFF
--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -220,6 +220,8 @@
     "copy_success": "Copy successful!",
     "created_at": "Created At",
     "updated_at": "Updated At",
+    "created_by": "Created By",
+    "updated_by": "Updated By",
     "expires_at": "Expires At",
     "no_more": "No more links",
     "load_failed": "Loading links failed,",

--- a/layers/dashboard/app/components/dashboard/links/Link.vue
+++ b/layers/dashboard/app/components/dashboard/links/Link.vue
@@ -192,6 +192,12 @@ function copyLink() {
                 <TooltipContent>
                   <p>{{ $t('links.created_at') }}: {{ longDate(link.createdAt, locale) }}</p>
                   <p>{{ $t('links.updated_at') }}: {{ longDate(link.updatedAt, locale) }}</p>
+                  <p v-if="link.createdBy">
+                    {{ $t('links.created_by') }}: {{ link.createdBy }}
+                  </p>
+                  <p v-if="link.updatedBy">
+                    {{ $t('links.updated_by') }}: {{ link.updatedBy }}
+                  </p>
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>

--- a/server/api/link/create.post.ts
+++ b/server/api/link/create.post.ts
@@ -58,6 +58,7 @@ export default eventHandler(async (event) => {
     })
   }
 
+  stampCreatedBy(event, link)
   await hashLinkPasswordForCreate(link)
 
   await putLink(event, link)

--- a/server/api/link/edit.put.ts
+++ b/server/api/link/edit.put.ts
@@ -61,6 +61,7 @@ export default eventHandler(async (event) => {
     await detectUnsafeLink(event, link)
 
   const newLink = mergeEditableLink(existingLink, link)
+  stampUpdatedBy(event, newLink)
   await applyEditableLinkPassword(newLink, link.password)
 
   await putLink(event, newLink)

--- a/server/api/link/upsert.post.ts
+++ b/server/api/link/upsert.post.ts
@@ -41,6 +41,7 @@ export default eventHandler(async (event) => {
     return { ...buildLinkResponse(event, existingLink), status: 'existing' }
   }
 
+  stampCreatedBy(event, link)
   await hashLinkPasswordForCreate(link)
 
   await putLink(event, link)

--- a/server/utils/cloudflare-access.ts
+++ b/server/utils/cloudflare-access.ts
@@ -1,6 +1,6 @@
 import type { H3Event } from 'h3'
 import type { JWTVerifyGetKey } from 'jose'
-import { createRemoteJWKSet, jwtVerify } from 'jose'
+import { createRemoteJWKSet, decodeJwt, jwtVerify } from 'jose'
 
 interface CloudflareAccessConfig {
   audience: string
@@ -53,8 +53,16 @@ export async function verifyCloudflareAccess(event: H3Event): Promise<boolean> {
     return false
 
   for (const token of getAccessTokens(event)) {
-    if (await verifyCloudflareAccessToken(token, { audience, issuer }))
+    if (await verifyCloudflareAccessToken(token, { audience, issuer })) {
+      // token is verified above; decode it to capture the email for attribution
+      try {
+        const { email } = decodeJwt(token)
+        if (typeof email === 'string')
+          event.context.accessUserEmail = email
+      }
+      catch {}
       return true
+    }
   }
 
   return false

--- a/server/utils/link-processing.ts
+++ b/server/utils/link-processing.ts
@@ -25,6 +25,24 @@ export async function prepareIncomingLink(event: H3Event, link: Link): Promise<v
   await detectUnsafeLink(event, link)
 }
 
+export function getLinkActor(event: H3Event): string {
+  if (event.context.accessUserEmail)
+    return event.context.accessUserEmail
+  if (event.context.authMethod === 'site-token')
+    return 'site-token'
+  return 'unknown'
+}
+
+export function stampCreatedBy(event: H3Event, link: Link): void {
+  const actor = getLinkActor(event)
+  link.createdBy = actor
+  link.updatedBy = actor
+}
+
+export function stampUpdatedBy(event: H3Event, link: Link): void {
+  link.updatedBy = getLinkActor(event)
+}
+
 export async function detectUnsafeLink(event: H3Event, link: Pick<Link, 'url' | 'unsafe'>): Promise<void> {
   if (link.unsafe !== undefined)
     return
@@ -53,6 +71,7 @@ export function mergeEditableLink(existingLink: Link, link: Link): Link {
     ...linkWithoutPassword,
     id: existingLink.id,
     createdAt: existingLink.createdAt,
+    createdBy: existingLink.createdBy,
     updatedAt: Math.floor(Date.now() / 1000),
   }
 

--- a/shared/schemas/link.ts
+++ b/shared/schemas/link.ts
@@ -34,6 +34,8 @@ export const LinkSchema = z.object({
   comment: z.string().trim().max(2048).optional(),
   createdAt: z.number().int().safe().default(() => Math.floor(Date.now() / 1000)),
   updatedAt: z.number().int().safe().default(() => Math.floor(Date.now() / 1000)),
+  createdBy: z.string().trim().max(320).optional(),
+  updatedBy: z.string().trim().max(320).optional(),
   expiration: z.number().int().safe().refine(expiration => expiration > Math.floor(Date.now() / 1000), {
     message: 'expiration must be greater than current time',
     path: ['expiration'],


### PR DESCRIPTION
## What

Adds `createdBy` / `updatedBy` to links so you can see who created or last edited each one.

## Why

Links carry no attribution today. When several people manage an instance — a dashboard behind Cloudflare Access, or multiple holders of the site token — there's no way to tell who made a change.

## How

- The actor is resolved **server-side** from the authenticated identity:
  - **Cloudflare Access** — the user's email, read from their already-verified Access JWT (the auth middleware verifies the signature; this decodes the same token for the `email` claim).
  - **Site token** — recorded as `site-token` (a shared token has no individual identity).
- `createdBy` is set on create and preserved across edits; `updatedBy` is refreshed on every edit.
- The fields are server-controlled — any client-supplied value is overwritten — and returned in the link API responses.
- The dashboard shows both in the link card's date tooltip, beside the existing created/updated timestamps, and only when present, so pre-existing links are unaffected until their next edit.

## Notes

- **Deletes aren't tracked** — once the record is gone there's nowhere to store it.
- New i18n keys are added to `en-US`; other locales fall back to it. Happy to add more.
- The email is only captured when a request comes through Cloudflare Access. If you'd prefer this be opt-in behind a config flag for privacy, I'm glad to gate it — just let me know.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
