### PR TITLE
fix: honor NUXT_HOME_URL on SPA navigation to /

### DIFF
--- a/app/composables/usePublicConfig.ts
+++ b/app/composables/usePublicConfig.ts
@@ -1,0 +1,12 @@
+import type { PublicConfig } from '@/types'
+
+let pending: Promise<PublicConfig> | null = null
+
+// Fetches the public `/_config` endpoint once per session (retries on failure).
+export function usePublicConfig(): Promise<PublicConfig> {
+  pending ??= $fetch<PublicConfig>('/_config').catch((error) => {
+    pending = null
+    throw error
+  })
+  return pending
+}

--- a/app/middleware/home.global.ts
+++ b/app/middleware/home.global.ts
@@ -1,0 +1,20 @@
+// When NUXT_HOME_URL is set, `/` must always resolve through the server
+// (server/middleware/1.redirect.ts) instead of the prerendered SPA homepage.
+export default defineNuxtRouteMiddleware(async (to, from) => {
+  if (import.meta.server)
+    return
+
+  // Initial load (from === to) is already handled server-side; only SPA
+  // navigations bypass the server and need a forced full-page load.
+  if (to.path !== '/' || from.path === '/')
+    return
+
+  try {
+    const { homeRedirect } = await usePublicConfig()
+    if (homeRedirect)
+      return navigateTo('/', { external: true })
+  }
+  catch {
+    // Config unavailable: fall through to the SPA homepage.
+  }
+})

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -1,4 +1,5 @@
 export * from '#shared/types/auth'
+export * from '#shared/types/config'
 export * from '#shared/types/events'
 export * from '#shared/types/link'
 export * from '#shared/types/link-check'

--- a/server/routes/_config.get.ts
+++ b/server/routes/_config.get.ts
@@ -1,0 +1,11 @@
+import type { PublicConfig } from '#shared/types/config'
+
+// Public, unauthenticated runtime configuration for the SPA client.
+// Only expose booleans or values that are safe for anonymous visitors;
+// never leak secrets or redirect targets.
+export default eventHandler((event): PublicConfig => {
+  const { homeURL } = useRuntimeConfig(event)
+  return {
+    homeRedirect: Boolean(homeURL),
+  }
+})

--- a/shared/types/config.ts
+++ b/shared/types/config.ts
@@ -1,0 +1,5 @@
+// Shape of the public, unauthenticated `/_config` endpoint.
+export interface PublicConfig {
+  /** Whether `/` redirects to an external home URL (NUXT_HOME_URL is set). */
+  homeRedirect: boolean
+}


### PR DESCRIPTION
Server middleware only redirects / on full page loads, so in-app navigation (e.g. dashboard logo) landed on the prerendered homepage instead of the configured home URL.

Add public /_config endpoint exposing a homeRedirect flag (never the target URL) and a global route middleware that forces a full-page load of / when set. Endpoint is unauthenticated by design and uses _ prefix so slug resolution skips it.

Fixes #320 