### PR TITLE
fix: support configurable long target URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,8 @@ NUXT_CF_API_TOKEN=
 NUXT_PUBLIC_PREVIEW_MODE=true
 NUXT_PUBLIC_SLUG_DEFAULT_LENGTH=6
 NUXT_PUBLIC_KV_BATCH_LIMIT=50
+# Maximum target URL length in characters (256-24000; default: 16384)
+NUXT_PUBLIC_MAX_URL_LENGTH=16384
 
 # Optional build configuration
 # Workers Build: set in Workers Builds variables.

--- a/app/components/dashboard/links/editor/Form.vue
+++ b/app/components/dashboard/links/editor/Form.vue
@@ -5,7 +5,7 @@ import { useForm } from '@tanstack/vue-form'
 import { useDebounceFn } from '@vueuse/core'
 import { toast } from 'vue-sonner'
 import { z } from 'zod'
-import { nanoid, SlugSchema, UrlSchema } from '#shared/schemas/link'
+import { MAX_URL_LENGTH, nanoid, SlugSchema } from '#shared/schemas/link'
 
 const props = defineProps<{
   link: Partial<DashboardLink>
@@ -23,10 +23,8 @@ const { t } = useI18n()
 const linksSearchStore = useDashboardLinksSearchStore()
 const requestUrl = useRequestURL()
 
-const urlValidator = UrlSchema
 const slugValidator = SlugSchema
 const commentValidator = z.string().max(500).optional()
-const optionalUrlValidator = z.string().trim().url().max(2048).optional().or(z.literal(''))
 
 const generateSlug = nanoid()
 
@@ -62,10 +60,29 @@ const tagsInput = useTemplateRef<{ commit: () => boolean }>('tagsInput')
 watch(isSubmitting, value => emit('update:submitting', value), { immediate: true })
 watch(isDirty, value => emit('update:dirty', value), { immediate: true })
 
-const validateUrl = makeZodValidator(urlValidator)
 const validateSlug = makeZodValidator(slugValidator)
 const validateComment = makeZodValidator(commentValidator)
-const validateOptionalUrl = makeZodValidator(optionalUrlValidator)
+
+function validateUrl({ value }: { value: unknown }): string | undefined {
+  return validateUrlValue(value, false)
+}
+
+function validateOptionalUrl({ value }: { value: unknown }): string | undefined {
+  return validateUrlValue(value, true)
+}
+
+function validateUrlValue(value: unknown, optional: boolean): string | undefined {
+  const error = getLinkUrlValidationError(value, MAX_URL_LENGTH, optional)
+  if (!error)
+    return undefined
+  if (error.kind === 'too_long') {
+    return t('links.form.url_too_long', {
+      length: error.length.toLocaleString(),
+      max: MAX_URL_LENGTH.toLocaleString(),
+    })
+  }
+  return t(`links.form.url_${error.kind}`)
+}
 
 const utmBuilderOpen = ref(false)
 const advancedSections = ref<string[]>([])
@@ -255,6 +272,9 @@ defineExpose({ initializeRandomSlug })
               @blur="field.handleBlur"
               @input="field.handleChange(($event.target as HTMLInputElement).value)"
             />
+            <FieldDescription v-if="!isInvalid(field) && !duplicateLink">
+              {{ $t('links.form.url_description', { max: MAX_URL_LENGTH.toLocaleString() }) }}
+            </FieldDescription>
             <FieldDescription
               v-if="!isInvalid(field) && duplicateLink"
               class="flex items-center gap-2"

--- a/app/composables/useDashboardLinksSearchStore.ts
+++ b/app/composables/useDashboardLinksSearchStore.ts
@@ -115,7 +115,8 @@ export const useDashboardLinksSearchStore = defineStore('dashboard-links-search'
       return undefined
 
     const matches = await useAPI<DashboardLinkSearchItem[]>('/api/link/search', {
-      query: {
+      method: 'POST',
+      body: {
         url: targetUrl,
         limit: 20,
       },

--- a/app/utils/link-form.ts
+++ b/app/utils/link-form.ts
@@ -2,6 +2,28 @@ import type { DashboardLink, DashboardLinkFormData } from '@/types/dashboard-lin
 import { isMaskedLinkPassword } from '#shared/utils/link-password'
 import { date2unix, unix2date } from './time'
 
+export type LinkUrlValidationError
+  = | { kind: 'required' }
+    | { kind: 'invalid' }
+    | { kind: 'too_long', length: number }
+
+export function getLinkUrlValidationError(
+  value: unknown,
+  maxUrlLength: number,
+  optional = false,
+): LinkUrlValidationError | undefined {
+  if (typeof value !== 'string')
+    return { kind: 'invalid' }
+
+  const url = value.trim()
+  if (!url)
+    return optional ? undefined : { kind: 'required' }
+  if (url.length > maxUrlLength)
+    return { kind: 'too_long', length: url.length }
+
+  return URL.canParse(url) ? undefined : { kind: 'invalid' }
+}
+
 export function createLinkFormInitialValues(link: Partial<DashboardLink>): DashboardLinkFormData {
   return {
     url: link.url ?? '',

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -76,6 +76,7 @@ On Workers, set the same value in Builds and runtime. On Pages, set once, then r
 | `NUXT_PUBLIC_PREVIEW_MODE`        | empty   | `true` = demo mode (links last 5 minutes)                 |
 | `NUXT_PUBLIC_SLUG_DEFAULT_LENGTH` | `6`     | Length of auto-generated short codes                      |
 | `NUXT_PUBLIC_KV_BATCH_LIMIT`      | `50`    | Export page size; import accepts at most half per request |
+| `NUXT_PUBLIC_MAX_URL_LENGTH`      | `16384` | Maximum target URL length in characters (256-24000)       |
 
 ## Optional
 

--- a/docs/zh-CN/configuration/index.md
+++ b/docs/zh-CN/configuration/index.md
@@ -76,6 +76,7 @@ Workers 要在 Builds 和运行时填相同值。Pages 只填一次，然后重�
 | `NUXT_PUBLIC_PREVIEW_MODE`        | 空   | `true` = 演示模式（链接只活 5 分钟） |
 | `NUXT_PUBLIC_SLUG_DEFAULT_LENGTH` | `6`  | 自动生成短链码的长度                 |
 | `NUXT_PUBLIC_KV_BATCH_LIMIT`      | `50` | 导出每页条数；导入每次最多一半       |
+| `NUXT_PUBLIC_MAX_URL_LENGTH`      | `16384` | 目标 URL 最大字符数（256-24000）     |
 
 ## 可选配置
 

--- a/i18n/locales/de-DE/links.json
+++ b/i18n/locales/de-DE/links.json
@@ -52,6 +52,10 @@
     },
     "form": {
       "url": "URL",
+      "url_description": "Gib eine vollständige URL wie https://example.com ein. Maximal {max} Zeichen.",
+      "url_required": "URL ist erforderlich.",
+      "url_invalid": "Das URL-Format ist ungültig. Gib eine vollständige URL wie https://example.com ein.",
+      "url_too_long": "Die URL hat {length} Zeichen, das Limit beträgt jedoch {max}.",
       "slug": "Slug",
       "comment": "Kommentar",
       "tags": "Tags",

--- a/i18n/locales/en-US/links.json
+++ b/i18n/locales/en-US/links.json
@@ -52,6 +52,10 @@
     },
     "form": {
       "url": "URL",
+      "url_description": "Enter a complete URL, such as https://example.com. Maximum {max} characters.",
+      "url_required": "URL is required.",
+      "url_invalid": "URL format is invalid. Enter a complete URL, such as https://example.com.",
+      "url_too_long": "URL is {length} characters long, but the limit is {max}.",
       "slug": "Slug",
       "comment": "Comment",
       "tags": "Tags",

--- a/i18n/locales/fr-FR/links.json
+++ b/i18n/locales/fr-FR/links.json
@@ -52,6 +52,10 @@
     },
     "form": {
       "url": "URL",
+      "url_description": "Saisissez une URL complète, comme https://example.com. {max} caractères maximum.",
+      "url_required": "L’URL est obligatoire.",
+      "url_invalid": "Le format de l’URL est invalide. Saisissez une URL complète, comme https://example.com.",
+      "url_too_long": "L’URL contient {length} caractères, mais la limite est de {max}.",
       "slug": "Slug",
       "comment": "Commentaire",
       "tags": "Tags",

--- a/i18n/locales/id-ID/links.json
+++ b/i18n/locales/id-ID/links.json
@@ -52,6 +52,10 @@
     },
     "form": {
       "url": "URL",
+      "url_description": "Masukkan URL lengkap, seperti https://example.com. Maksimal {max} karakter.",
+      "url_required": "URL wajib diisi.",
+      "url_invalid": "Format URL tidak valid. Masukkan URL lengkap, seperti https://example.com.",
+      "url_too_long": "URL memiliki {length} karakter, tetapi batasnya {max}.",
       "slug": "Slug",
       "comment": "Catatan",
       "tags": "Tag",

--- a/i18n/locales/it-IT/links.json
+++ b/i18n/locales/it-IT/links.json
@@ -52,6 +52,10 @@
     },
     "form": {
       "url": "URL",
+      "url_description": "Inserisci un URL completo, come https://example.com. Massimo {max} caratteri.",
+      "url_required": "L’URL è obbligatorio.",
+      "url_invalid": "Il formato dell’URL non è valido. Inserisci un URL completo, come https://example.com.",
+      "url_too_long": "L’URL contiene {length} caratteri, ma il limite è {max}.",
       "slug": "Slug",
       "comment": "Commento",
       "tags": "Tag",

--- a/i18n/locales/ko-KR/links.json
+++ b/i18n/locales/ko-KR/links.json
@@ -52,6 +52,10 @@
     },
     "form": {
       "url": "URL",
+      "url_description": "https://example.com과 같은 완전한 URL을 입력하세요. 최대 {max}자입니다.",
+      "url_required": "URL을 입력하세요.",
+      "url_invalid": "URL 형식이 올바르지 않습니다. https://example.com과 같은 완전한 URL을 입력하세요.",
+      "url_too_long": "URL이 {length}자이지만 제한은 {max}자입니다.",
       "slug": "슬러그",
       "comment": "설명",
       "tags": "태그",

--- a/i18n/locales/pt-BR/links.json
+++ b/i18n/locales/pt-BR/links.json
@@ -52,6 +52,10 @@
     },
     "form": {
       "url": "URL",
+      "url_description": "Insira uma URL completa, como https://example.com. Máximo de {max} caracteres.",
+      "url_required": "A URL é obrigatória.",
+      "url_invalid": "O formato da URL é inválido. Insira uma URL completa, como https://example.com.",
+      "url_too_long": "A URL tem {length} caracteres, mas o limite é {max}.",
       "slug": "Slug",
       "comment": "Comentário",
       "tags": "Tags",

--- a/i18n/locales/pt-PT/links.json
+++ b/i18n/locales/pt-PT/links.json
@@ -52,6 +52,10 @@
     },
     "form": {
       "url": "URL",
+      "url_description": "Introduza um URL completo, como https://example.com. Máximo de {max} caracteres.",
+      "url_required": "O URL é obrigatório.",
+      "url_invalid": "O formato do URL é inválido. Introduza um URL completo, como https://example.com.",
+      "url_too_long": "O URL tem {length} caracteres, mas o limite é {max}.",
       "slug": "Slug",
       "comment": "Comentário",
       "tags": "Etiquetas",

--- a/i18n/locales/vi-VN/links.json
+++ b/i18n/locales/vi-VN/links.json
@@ -52,6 +52,10 @@
     },
     "form": {
       "url": "URL",
+      "url_description": "Nhập URL đầy đủ, chẳng hạn https://example.com. Tối đa {max} ký tự.",
+      "url_required": "URL là bắt buộc.",
+      "url_invalid": "Định dạng URL không hợp lệ. Hãy nhập URL đầy đủ, chẳng hạn https://example.com.",
+      "url_too_long": "URL có {length} ký tự, nhưng giới hạn là {max}.",
       "slug": "Slug",
       "comment": "Ghi chú",
       "tags": "Thẻ",

--- a/i18n/locales/zh-CN/links.json
+++ b/i18n/locales/zh-CN/links.json
@@ -52,6 +52,10 @@
     },
     "form": {
       "url": "链接地址",
+      "url_description": "请输入完整链接，例如 https://example.com，最多 {max} 个字符。",
+      "url_required": "链接地址不能为空。",
+      "url_invalid": "链接格式无效，请输入完整链接，例如 https://example.com。",
+      "url_too_long": "链接长度为 {length} 个字符，超过上限 {max} 个字符。",
       "slug": "短链",
       "comment": "备注",
       "tags": "标签",

--- a/i18n/locales/zh-TW/links.json
+++ b/i18n/locales/zh-TW/links.json
@@ -52,6 +52,10 @@
     },
     "form": {
       "url": "連結地址",
+      "url_description": "請輸入完整連結，例如 https://example.com，最多 {max} 個字元。",
+      "url_required": "連結地址不能為空白。",
+      "url_invalid": "連結格式無效，請輸入完整連結，例如 https://example.com。",
+      "url_too_long": "連結長度為 {length} 個字元，超過上限 {max} 個字元。",
       "slug": "短連結",
       "comment": "備註",
       "tags": "標籤",

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -46,6 +46,7 @@ export default defineNuxtConfig({
       previewMode: '',
       slugDefaultLength: '6',
       kvBatchLimit: '50',
+      maxUrlLength: '16384',
     },
   },
   routeRules: {

--- a/server/api/link/count.get.ts
+++ b/server/api/link/count.get.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { MAX_URL_LENGTH } from '#shared/schemas/link'
 
 defineRouteMeta({
   openAPI: {
@@ -41,7 +42,7 @@ const CountQuerySchema = z.object({
   q: z.string().trim().refine(value => new TextEncoder().encode(value.toLowerCase().replace(/[!%_]/g, '!$&')).length <= 48, {
     message: 'Search query must not exceed 48 UTF-8 bytes',
   }).optional(),
-  url: z.string().trim().url().max(2048).optional(),
+  url: z.string().trim().url().max(MAX_URL_LENGTH).optional(),
   tag: z.string().trim().toLowerCase().min(1).max(32).optional(),
   status: z.enum(['active', 'expired', 'all']).default('active'),
 })

--- a/server/api/link/search.get.ts
+++ b/server/api/link/search.get.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { MAX_URL_LENGTH } from '#shared/schemas/link'
 
 defineRouteMeta({
   openAPI: {
@@ -48,7 +49,7 @@ const SearchQuerySchema = z.object({
   q: z.string().trim().refine(value => new TextEncoder().encode(value.toLowerCase().replace(/[!%_]/g, '!$&')).length <= 48, {
     message: 'Search query must not exceed 48 UTF-8 bytes',
   }).optional(),
-  url: z.string().trim().url().max(2048).optional(),
+  url: z.string().trim().url().max(MAX_URL_LENGTH).optional(),
   limit: z.coerce.number().int().min(1).max(1000).optional(),
   tag: z.string().trim().toLowerCase().min(1).max(32).optional(),
   status: z.enum(['active', 'expired', 'all']).default('active'),

--- a/server/api/link/search.post.ts
+++ b/server/api/link/search.post.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod'
+import { UrlSchema } from '#shared/schemas/link'
+
+defineRouteMeta({
+  openAPI: {
+    description: 'Search links by an exact target URL without placing the URL in the request query string',
+    security: [{ bearerAuth: [] }],
+    requestBody: {
+      required: true,
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            required: ['url'],
+            properties: {
+              url: { type: 'string', description: 'Normalized target URL to match exactly' },
+              limit: { type: 'integer', minimum: 1, maximum: 1000, default: 20 },
+            },
+          },
+        },
+      },
+    },
+  },
+})
+
+const ExactUrlSearchSchema = z.object({
+  url: UrlSchema,
+  limit: z.coerce.number().int().min(1).max(1000).default(20),
+})
+
+export default eventHandler(async (event) => {
+  const query = await readValidatedBody(event, ExactUrlSearchSchema.parse)
+  return await searchLinks(event, query)
+})

--- a/shared/schemas/link-check.ts
+++ b/shared/schemas/link-check.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { MAX_URL_LENGTH } from './link'
 
 function isHttpUrl(value: string): boolean {
   try {
@@ -12,7 +13,7 @@ function isHttpUrl(value: string): boolean {
 
 export const LinkCheckTargetSchema = z.object({
   slug: z.string().trim().min(1).max(2048),
-  url: z.string().trim().url().max(2048).refine(isHttpUrl, 'URL must use HTTP or HTTPS'),
+  url: z.string().trim().url().max(MAX_URL_LENGTH).refine(isHttpUrl, 'URL must use HTTP or HTTPS'),
 })
 
 export const LinkCheckRequestSchema = z.object({

--- a/shared/schemas/link.ts
+++ b/shared/schemas/link.ts
@@ -5,6 +5,20 @@ import { LINK_PASSWORD_MASK_PREFIX } from '../utils/link-password'
 const { slugRegex } = useAppConfig()
 
 const slugDefaultLength = +useRuntimeConfig().public.slugDefaultLength
+const configuredMaxUrlLength = Number(useRuntimeConfig().public.maxUrlLength)
+const MIN_CONFIGURED_URL_LENGTH = 256
+// Leaves room under Cloudflare's 128 KB response-header limit after URL encoding.
+const MAX_CONFIGURED_URL_LENGTH = 24_000
+
+if (!Number.isSafeInteger(configuredMaxUrlLength)
+  || configuredMaxUrlLength < MIN_CONFIGURED_URL_LENGTH
+  || configuredMaxUrlLength > MAX_CONFIGURED_URL_LENGTH) {
+  throw new Error(
+    `NUXT_PUBLIC_MAX_URL_LENGTH must be an integer between ${MIN_CONFIGURED_URL_LENGTH} and ${MAX_CONFIGURED_URL_LENGTH}`,
+  )
+}
+
+export const MAX_URL_LENGTH = configuredMaxUrlLength
 
 export const nanoid = (length: number = slugDefaultLength) => customAlphabet('23456789abcdefghjkmnpqrstuvwxyz', length)
 
@@ -15,7 +29,7 @@ const GeoSchema = z.preprocess((value) => {
   return Object.fromEntries(
     Object.entries(value as Record<string, unknown>).map(([key, url]) => [key.trim().toUpperCase(), url]),
   )
-}, z.record(z.string().trim().regex(/^[A-Z]{2}$/), z.string().trim().url().max(2048)))
+}, z.record(z.string().trim().regex(/^[A-Z]{2}$/), z.string().trim().url().max(MAX_URL_LENGTH)))
 
 const TagsSchema = z.preprocess((value) => {
   if (!Array.isArray(value))
@@ -34,7 +48,11 @@ export const EditLinkPasswordSchema = z.string().trim().max(128).refine(
 ).optional()
 
 const IdSchema = z.string().trim().min(1).max(26)
-export const UrlSchema = z.string().trim().url().max(2048)
+export const UrlSchema = z.string()
+  .trim()
+  .min(1, 'URL is required')
+  .max(MAX_URL_LENGTH, `URL must not exceed ${MAX_URL_LENGTH} characters`)
+  .url('URL format is invalid')
 export const SlugSchema = z.string().trim().max(2048).regex(new RegExp(slugRegex))
 const TimestampSchema = z.number().int().safe()
 const ExpirationSchema = TimestampSchema.refine(expiration => expiration > Math.floor(Date.now() / 1000), {
@@ -50,8 +68,8 @@ const LinkFieldsSchema = z.object({
   title: z.string().trim().max(256).optional(),
   description: z.string().trim().max(2048).optional(),
   image: z.string().trim().max(128).optional(),
-  apple: z.string().trim().url().max(2048).optional(),
-  google: z.string().trim().url().max(2048).optional(),
+  apple: z.string().trim().url().max(MAX_URL_LENGTH).optional(),
+  google: z.string().trim().url().max(MAX_URL_LENGTH).optional(),
   cloaking: z.boolean().optional(),
   redirectWithQuery: z.boolean().optional(),
   password: LinkPasswordSchema.optional(),

--- a/tests/api/link.spec.ts
+++ b/tests/api/link.spec.ts
@@ -114,6 +114,35 @@ describe('/api/link/create', { concurrent: false }, () => {
     expect(data.shortLink).toContain(payload.slug)
   })
 
+  it('creates and searches for a long target URL', async () => {
+    const slug = trackSlug(`long-url-${crypto.randomUUID()}`)
+    const url = `https://example.com/preview?payload=${'a'.repeat(9_000)}`
+    const response = await postJson('/api/link/create', { url, slug })
+
+    expect(response.status).toBe(201)
+    const data = await response.json() as { link: { url: string } }
+    expect(data.link.url).toBe(url)
+
+    const searchResponse = await postJson('/api/link/search', { url, limit: 20 })
+    expect(searchResponse.status).toBe(200)
+    expect(await searchResponse.json()).toEqual([expect.objectContaining({
+      slug,
+      url: 'https://example.com/preview',
+    })])
+  })
+
+  it('returns 400 when URL exceeds the configured maximum length', async () => {
+    const url = `https://example.com/?payload=${'a'.repeat(16_384)}`
+    const response = await postJson('/api/link/create', {
+      url,
+      slug: `overlong-url-${crypto.randomUUID()}`,
+    })
+
+    expect(response.status).toBe(400)
+    const data = await response.json() as { data: { message: string } }
+    expect(data.data.message).toContain('URL must not exceed 16384 characters')
+  })
+
   it('returns 409 when slug already exists', async () => {
     const payload = createLinkPayload()
     await postJson('/api/link/create', payload)

--- a/tests/unit/dashboard-links-search-store.spec.ts
+++ b/tests/unit/dashboard-links-search-store.spec.ts
@@ -60,6 +60,20 @@ describe('dashboard links search store', () => {
     expect(store.requestStatus).toBe('idle')
   })
 
+  it('checks exact URL duplicates in a request body', async () => {
+    const store = useDashboardLinksSearchStore()
+
+    await store.findDuplicateLink('https://example.com/path?ignored=1')
+
+    expect(useAPIMock).toHaveBeenLastCalledWith('/api/link/search', {
+      method: 'POST',
+      body: {
+        url: 'https://example.com/path',
+        limit: 20,
+      },
+    })
+  })
+
   it('distinguishes idle, loading, successful empty, and error states', async () => {
     const store = useDashboardLinksSearchStore()
     let resolveSearch: ((value: []) => void) | undefined

--- a/tests/unit/link-form.spec.ts
+++ b/tests/unit/link-form.spec.ts
@@ -2,6 +2,7 @@ import { CalendarDate } from '@internationalized/date'
 import { describe, expect, it, vi } from 'vitest'
 import {
   createLinkFormInitialValues,
+  getLinkUrlValidationError,
   normalizeLinkFormSubmitPayload,
 } from '../../app/utils/link-form'
 import { LINK_PASSWORD_MASK_PREFIX } from '../../shared/utils/link-password'
@@ -42,6 +43,22 @@ describe('link form values', () => {
       { country: 'us', url: ' https://us.example.com ' },
       { country: 'CA', url: 'https://ca.example.com' },
     ])
+  })
+})
+
+describe('link URL validation', () => {
+  it('distinguishes required, invalid, and over-limit URLs', () => {
+    expect(getLinkUrlValidationError('  ', 20)).toEqual({ kind: 'required' })
+    expect(getLinkUrlValidationError('not a URL', 20)).toEqual({ kind: 'invalid' })
+    expect(getLinkUrlValidationError('https://example.com/long', 20)).toEqual({
+      kind: 'too_long',
+      length: 24,
+    })
+  })
+
+  it('accepts complete URLs and optional empty values', () => {
+    expect(getLinkUrlValidationError('https://example.com', 100)).toBeUndefined()
+    expect(getLinkUrlValidationError('', 100, true)).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
Supersedes #331

Raise the shared URL length contract behind a validated public runtime setting, surface specific localized validation errors, and move exact URL duplicate checks to POST so Cloudflare request URL limits do not reject long targets.

